### PR TITLE
fix: brand SVG sizing, FA icon overflow, and viewport-aware tooltip/popover flip

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 Personal CSS framework based on Bootstrap v4. Vanilla JS, no framework dependencies.
 
+The public-facing project overview is in [`README.md`](README.md) at the project root — update it when components, JS behaviour, or utilities change.
+
 ## Requirements
 
 - Node v24 (see `.nvmrc`)
@@ -76,10 +78,11 @@ src/
 │   ├── dropdown.js           # Dropdown menu toggle
 │   ├── menuToggle.js         # Responsive nav toggle, aria-expanded
 │   ├── modal.js              # Modal open/close, focus trap
-│   ├── popover.js            # Popover toggle and positioning
+│   ├── popover.js            # Popover toggle, positioning, and viewport flip
 │   ├── scrollHeader.js       # Hide/show header on scroll, --headerHeight CSS var
 │   ├── tabs.js               # Tab panel switching
-│   └── throttle.js           # Scroll event throttle utility
+│   ├── throttle.js           # Scroll event throttle utility
+│   └── tooltip.js            # Tooltip viewport-aware flip (sets data-tooltip-flip)
 └── index.html
 ```
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ A personal CSS framework built loosely on Bootstrap v4. Covers common layout, co
 
 **Utilities** — aspect ratio, background colours (`bg-*`, `text-bg-*`), borders (per-side, colour, width, radius), display (`d-*`), flex (`flex-*`, `align-items-*`, `justify-content-*`, `gap-*`), grid (12-column CSS grid, `grid-cols-*`, `col-*`), overflow, position (static through fixed, sticky top/bottom), shadows (`shadow-none` → `shadow-xl`), spacing (Bootstrap-compatible `mt-*`/`ps-*` etc., 0–8 scale), text (colour, size, weight, transform), z-index (numeric + semantic scale)
 
-**JavaScript** — accordion/disclosure, alert dismissal, dropdown toggle, modal (focus-trapped), popover, responsive menu toggle, scroll-aware header, tab panel switching, form validation via [Formbouncer](https://github.com/cferdinandi/bouncer)
+**JavaScript** — accordion/disclosure, alert dismissal, dropdown toggle, modal (focus-trapped), popover (with viewport-aware flip), responsive menu toggle, scroll-aware header, tab panel switching, tooltip (viewport-aware flip), form validation via [Formbouncer](https://github.com/cferdinandi/bouncer)
 
 ## Usage
 

--- a/src/css/scss/_forms.scss
+++ b/src/css/scss/_forms.scss
@@ -15,6 +15,7 @@
 
   &--inline {
     display: flex;
+    flex-wrap: wrap;
     margin: 0 0.2rem;
 
     & input,

--- a/src/css/scss/_icons.scss
+++ b/src/css/scss/_icons.scss
@@ -1,9 +1,13 @@
-.icon {
+.icon,
+.svg-inline--fa {
   font-size: inherit;
   height: 1em;
+  overflow: visible;
   vertical-align: -0.125em;
+  width: auto;
 
-  &--fw {
+  &--fw,
+  &.fa-fw {
     width: 0.875em;
   }
 }

--- a/src/css/scss/_popovers.scss
+++ b/src/css/scss/_popovers.scss
@@ -155,6 +155,125 @@ $_gap: 0.625rem; // gap between trigger edge and panel edge
         transform: translateY(-50%);
       }
     }
+
+    // --- Flip overrides set by popover.js when the preferred placement overflows the viewport.
+    // Attribute selector specificity (0,2,0) beats single placement-class modifiers (0,1,0).
+
+    &[data-popover-flip='top'] {
+      bottom: calc(100% + #{$_gap});
+      left: 50%;
+      top: auto;
+      transform: translateX(-50%);
+
+      &::before {
+        border-bottom: 0;
+        border-left: $_ao solid transparent;
+        border-right: $_ao solid transparent;
+        border-top: $_ao solid var(--grey200);
+        bottom: -#{$_ao};
+        left: 50%;
+        top: auto;
+        transform: translateX(-50%);
+      }
+
+      &::after {
+        border-bottom: 0;
+        border-left: $_ai solid transparent;
+        border-right: $_ai solid transparent;
+        border-top: $_ai solid var(--bodyBg);
+        bottom: -#{$_ai};
+        left: 50%;
+        top: auto;
+        transform: translateX(-50%);
+      }
+    }
+
+    &[data-popover-flip='bottom'] {
+      bottom: auto;
+      left: 50%;
+      top: calc(100% + #{$_gap});
+      transform: translateX(-50%);
+
+      &::before {
+        border-bottom: $_ao solid var(--grey200);
+        border-left: $_ao solid transparent;
+        border-right: $_ao solid transparent;
+        border-top: 0;
+        bottom: auto;
+        left: 50%;
+        top: -#{$_ao};
+        transform: translateX(-50%);
+      }
+
+      &::after {
+        border-bottom: $_ai solid var(--bodyBg);
+        border-left: $_ai solid transparent;
+        border-right: $_ai solid transparent;
+        border-top: 0;
+        bottom: auto;
+        left: 50%;
+        top: -#{$_ai};
+        transform: translateX(-50%);
+      }
+    }
+
+    &[data-popover-flip='right'] {
+      left: calc(100% + #{$_gap});
+      right: auto;
+      top: 50%;
+      transform: translateY(-50%);
+
+      &::before {
+        border-bottom: $_ao solid transparent;
+        border-left: 0;
+        border-right: $_ao solid var(--grey200);
+        border-top: $_ao solid transparent;
+        left: -#{$_ao};
+        right: auto;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      &::after {
+        border-bottom: $_ai solid transparent;
+        border-left: 0;
+        border-right: $_ai solid var(--bodyBg);
+        border-top: $_ai solid transparent;
+        left: -#{$_ai};
+        right: auto;
+        top: 50%;
+        transform: translateY(-50%);
+      }
+    }
+
+    &[data-popover-flip='left'] {
+      left: auto;
+      right: calc(100% + #{$_gap});
+      top: 50%;
+      transform: translateY(-50%);
+
+      &::before {
+        border-bottom: $_ao solid transparent;
+        border-left: $_ao solid var(--grey200);
+        border-right: 0;
+        border-top: $_ao solid transparent;
+        left: auto;
+        right: -#{$_ao};
+        top: 50%;
+        transform: translateY(-50%);
+      }
+
+      &::after {
+        border-bottom: $_ai solid transparent;
+        border-left: $_ai solid var(--bodyBg);
+        border-right: 0;
+        border-top: $_ai solid transparent;
+        left: auto;
+        right: -#{$_ai};
+        top: 50%;
+        transform: translateY(-50%);
+      }
+    }
   }
 
   &__title {

--- a/src/css/scss/_reset.scss
+++ b/src/css/scss/_reset.scss
@@ -56,10 +56,15 @@ figcaption {
 img,
 picture,
 video,
-canvas,
-svg {
+canvas {
   display: block;
   max-width: 100%;
+}
+
+/* Keep SVGs out of the shared media max-width rule so icons and inline artwork
+   retain their intrinsic sizing unless a component opts into responsive scaling. */
+svg {
+  display: block;
 }
 
 /* Form elements inherit font */

--- a/src/css/scss/_tooltips.scss
+++ b/src/css/scss/_tooltips.scss
@@ -10,7 +10,7 @@
  * .tooltip--left, .tooltip--right
  */
 
-$_arrow: 0.41rem;   // border-width that forms the triangle
+$_arrow: 0.41rem;   // border-width that forms the triangle, slightly larger than expected to account for anti-aliasing bleed
 $_gap: 0.25rem;    // space between element edge and arrow tip
 $_total: $_gap + $_arrow; // 0.66rem — element edge to bubble edge
 

--- a/src/css/scss/_tooltips.scss
+++ b/src/css/scss/_tooltips.scss
@@ -10,9 +10,9 @@
  * .tooltip--left, .tooltip--right
  */
 
-$_arrow: 0.4rem;   // border-width that forms the triangle
+$_arrow: 0.41rem;   // border-width that forms the triangle
 $_gap: 0.25rem;    // space between element edge and arrow tip
-$_total: $_gap + $_arrow + 0.1rem; // 0.75rem — element edge to bubble edge
+$_total: $_gap + $_arrow; // 0.66rem — element edge to bubble edge
 
 .tooltip {
   display: inline-block;

--- a/src/css/scss/_tooltips.scss
+++ b/src/css/scss/_tooltips.scss
@@ -127,4 +127,95 @@ $_total: $_gap + $_arrow; // 0.66rem — element edge to bubble edge
       transform: translateY(-50%);
     }
   }
+
+  // Flip overrides set by tooltip.js when the preferred placement overflows the viewport.
+  // Attribute selector specificity (0,2,0) beats single placement-class modifiers (0,1,0).
+
+  &[data-tooltip-flip='top'] {
+    &::before {
+      bottom: calc(100% + #{$_total});
+      left: 50%;
+      right: auto;
+      top: auto;
+      transform: translateX(-50%);
+    }
+
+    &::after {
+      border-bottom: 0;
+      border-left: $_arrow solid transparent;
+      border-right: $_arrow solid transparent;
+      border-top: $_arrow solid $grey-900;
+      bottom: calc(100% + #{$_gap});
+      left: 50%;
+      right: auto;
+      top: auto;
+      transform: translateX(-50%);
+    }
+  }
+
+  &[data-tooltip-flip='bottom'] {
+    &::before {
+      bottom: auto;
+      left: 50%;
+      right: auto;
+      top: calc(100% + #{$_total});
+      transform: translateX(-50%);
+    }
+
+    &::after {
+      border-bottom: $_arrow solid $grey-900;
+      border-left: $_arrow solid transparent;
+      border-right: $_arrow solid transparent;
+      border-top: 0;
+      bottom: auto;
+      left: 50%;
+      right: auto;
+      top: calc(100% + #{$_gap});
+      transform: translateX(-50%);
+    }
+  }
+
+  &[data-tooltip-flip='left'] {
+    &::before {
+      bottom: auto;
+      left: auto;
+      right: calc(100% + #{$_total});
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    &::after {
+      border-bottom: $_arrow solid transparent;
+      border-left: $_arrow solid $grey-900;
+      border-right: 0;
+      border-top: $_arrow solid transparent;
+      bottom: auto;
+      left: auto;
+      right: calc(100% + #{$_gap});
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
+
+  &[data-tooltip-flip='right'] {
+    &::before {
+      bottom: auto;
+      left: calc(100% + #{$_total});
+      right: auto;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+
+    &::after {
+      border-bottom: $_arrow solid transparent;
+      border-left: 0;
+      border-right: $_arrow solid $grey-900;
+      border-top: $_arrow solid transparent;
+      bottom: auto;
+      left: calc(100% + #{$_gap});
+      right: auto;
+      top: 50%;
+      transform: translateY(-50%);
+    }
+  }
 }

--- a/src/css/scss/layouts/_header.scss
+++ b/src/css/scss/layouts/_header.scss
@@ -24,7 +24,7 @@
   &--fixed {
     position: fixed;
     top: 0;
-    width: 100vw;
+    width: 100%;
     z-index: $z-index-above;
   }
 
@@ -45,7 +45,7 @@
     // https://codingreflections.com/hide-header-on-scroll-down/
     position: fixed;
     top: 0;
-    width: 100vw;
+    width: 100%;
     z-index: $z-index-raised;
     transition: top 0.3s ease;
 

--- a/src/css/scss/layouts/_header.scss
+++ b/src/css/scss/layouts/_header.scss
@@ -24,7 +24,7 @@
   &--fixed {
     position: fixed;
     top: 0;
-    width: 100%;
+    width: 100vw;
     z-index: $z-index-above;
   }
 
@@ -45,7 +45,7 @@
     // https://codingreflections.com/hide-header-on-scroll-down/
     position: fixed;
     top: 0;
-    width: 100%;
+    width: 100vw;
     z-index: $z-index-raised;
     transition: top 0.3s ease;
 

--- a/src/index.html
+++ b/src/index.html
@@ -69,6 +69,7 @@
             xmlns="http://www.w3.org/2000/svg"
             viewBox="0 0 512 512"
             width="40"
+            height="40"
           >
             <rect class="np__bg" x="0" width="512" height="512" rx="51.2" />
             <path
@@ -98,7 +99,7 @@
       </nav>
 
       <div id="toolbar" class="toolbar toolbar--right collapsed">
-        <span class="fa-duotone fa-sharp fa-light fa-user-hair-buns"></span>
+        <span class="fa-duotone fa-sharp fa-light fa-user-hair-buns icon"></span>
         <span>User Name</span>
 
         <button
@@ -108,7 +109,7 @@
           data-mode="dark"
           data-toggle-dark-mode
         >
-          <span class="fa-duotone fa-sharp fa-light fa-eclipse-alt"></span>
+          <span class="fa-duotone fa-sharp fa-light fa-eclipse-alt icon"></span>
           <span class="visually-hidden">Toggle dark mode</span>
         </button>
 
@@ -117,7 +118,7 @@
           type="button"
           title="Settings"
         >
-          <span class="fa-duotone fa-sharp fa-light fa-cog"></span>
+          <span class="fa-duotone fa-sharp fa-light fa-cog icon"></span>
           <span class="visually-hidden">Settings</span>
         </button>
 
@@ -126,7 +127,7 @@
           type="button"
           title="Sign out"
         >
-          <span class="fa-duotone fa-sharp fa-light fa-sign-out-alt"></span>
+          <span class="fa-duotone fa-sharp fa-light fa-sign-out-alt icon"></span>
           <span class="visually-hidden">Sign out</span>
         </button>
       </div>
@@ -135,11 +136,11 @@
         id="menu-toggle"
         class="nav__control button button--default"
         type="button"
-        aria-controls="navigation, toolbar"
+        aria-controls="navigation toolbar"
         aria-expanded="false"
         aria-label="Toggle navigation and toolbar"
       >
-        <span class="fa-duotone fa-sharp fa-light fa-bars"></span
+        <span class="fa-duotone fa-sharp fa-light fa-bars icon"></span
         ><span class="visually-hidden">Menu</span>
       </button>
     </header>
@@ -148,7 +149,7 @@
       <section class="section">
         <h1>Colours</h1>
         <div class="flex flex--grid">
-          <div class="card flex__item flex__item--4">
+          <div class="card flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Default</h2>
             </div>
@@ -168,7 +169,7 @@
             </div>
           </div>
 
-          <div class="card card--primary flex__item flex__item--4">
+          <div class="card card--primary flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Primary</h2>
             </div>
@@ -188,7 +189,7 @@
             </div>
           </div>
 
-          <div class="card card--secondary flex__item flex__item--4">
+          <div class="card card--secondary flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Secondary</h2>
             </div>
@@ -208,7 +209,7 @@
             </div>
           </div>
 
-          <div class="card card--info flex__item flex__item--4">
+          <div class="card card--info flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Information</h2>
             </div>
@@ -228,7 +229,7 @@
             </div>
           </div>
 
-          <div class="card card--success flex__item flex__item--4">
+          <div class="card card--success flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Success</h2>
             </div>
@@ -248,7 +249,7 @@
             </div>
           </div>
 
-          <div class="card card--warning flex__item flex__item--4">
+          <div class="card card--warning flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Warning</h2>
             </div>
@@ -268,7 +269,7 @@
             </div>
           </div>
 
-          <div class="card card--danger flex__item flex__item--4">
+          <div class="card card--danger flex__item flex__item--12 flex__item--6-sm flex__item--4-md">
             <div class="card__title">
               <h2>Danger</h2>
             </div>
@@ -768,6 +769,8 @@
 
         <h2>Inline</h2>
 
+        <p><code>.form--inline</code> class can be used to display form controls inline. On smaller screens, the controls will wrap to the next line.</p>
+
         <form class="form form--inline">
           <div class="form__group">
             <label class="form__label">Input label</label>
@@ -1131,12 +1134,12 @@
       <section class="section">
         <h1>Cards</h1>
 
-        <p>
+        <p class="mb-4">
           Already used as an example for Colours, cards have a title and body.
         </p>
 
         <div class="flex flex--grid">
-          <div class="card flex__item flex__item--3">
+          <div class="card flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Default</h2>
             </div>
@@ -1145,7 +1148,7 @@
             </div>
           </div>
 
-          <div class="card card--primary flex__item flex__item--3">
+          <div class="card card--primary flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Primary</h2>
             </div>
@@ -1154,7 +1157,7 @@
             </div>
           </div>
 
-          <div class="card card--secondary flex__item flex__item--3">
+          <div class="card card--secondary flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Secondary</h2>
             </div>
@@ -1163,7 +1166,7 @@
             </div>
           </div>
 
-          <div class="card card--info flex__item flex__item--3">
+          <div class="card card--info flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Information</h2>
             </div>
@@ -1172,7 +1175,7 @@
             </div>
           </div>
 
-          <div class="card card--success flex__item flex__item--3">
+          <div class="card card--success flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Success</h2>
             </div>
@@ -1181,7 +1184,7 @@
             </div>
           </div>
 
-          <div class="card card--warning flex__item flex__item--3">
+          <div class="card card--warning flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Warning</h2>
             </div>
@@ -1190,7 +1193,7 @@
             </div>
           </div>
 
-          <div class="card card--danger flex__item flex__item--3">
+          <div class="card card--danger flex__item flex__item--12 flex__item--6-sm flex__item--3-md">
             <div class="card__title">
               <h2>Danger</h2>
             </div>
@@ -1202,7 +1205,7 @@
 
         <h2>Dark variants</h2>
 
-        <p>As with buttons, cards also come in a <code>-dark</code> variant.</p>
+        <p class="mb-4">As with buttons, cards also come in a <code>-dark</code> variant.</p>
 
         <div class="flex flex--grid">
           <div
@@ -1453,10 +1456,10 @@
 
         <p>
           <a href="#" class="button button--primary">
-            Notifications <span class="badge badge--light">12</span>
+            Notifications <span class="badge badge--light ms-1">12</span>
           </a>
           <a href="#" class="button button--dark">
-            Alerts <span class="badge badge--pill badge--danger">3</span>
+            Alerts <span class="badge badge--pill badge--danger ms-1">3</span>
           </a>
         </p>
       </section>
@@ -2239,7 +2242,9 @@
           <li>0.5rem vertical padding: <code>p-v-sm</code></li>
           <li>No padding: <code>p-0</code></li>
         </ul>
+      </section>
 
+      <section class="section">
         <h2>Text</h2>
 
         <p>
@@ -2363,7 +2368,9 @@
           <span class="text-uppercase fw-light text-sm">fun variations</span
           >.
         </p>
+      </section>
 
+      <section class="section">
         <h2>Display</h2>
 
         <h3>Display values</h3>
@@ -2429,7 +2436,9 @@
           <li><code>gap-x-{n}</code> — columns only</li>
           <li><code>gap-y-{n}</code> — rows only</li>
         </ul>
+      </section>
 
+      <section class="section">
         <h2>Overflow</h2>
 
         <table class="table table--striped table--sm">
@@ -2450,7 +2459,9 @@
             <tr><td><code>overflow-y-scroll</code></td><td><code>overflow-y: scroll</code></td></tr>
           </tbody>
         </table>
+      </section>
 
+      <section class="section">
         <h2>Position</h2>
 
         <table class="table table--striped table--sm">
@@ -2501,7 +2512,9 @@
           <span class="position-absolute bottom-0 start-0 badge badge--secondary">bottom / start</span>
           <span class="position-absolute bottom-0 end-0 badge badge--secondary">bottom / end</span>
         </div>
+      </section>
 
+      <section class="section">
         <h2>Shadows</h2>
 
         <p>Box-shadow utility scale — values use <code>px</code> as is standard for decorative effects.</p>
@@ -2515,7 +2528,9 @@
           <div class="shadow-inner p-4 rounded">shadow-inner</div>
           <div class="shadow-none border p-4 rounded">shadow-none</div>
         </div>
+      </section>
 
+      <section class="section">
         <h2>Borders</h2>
 
         <h3>Adding borders</h3>
@@ -2565,7 +2580,9 @@
           <div class="border rounded-pill px-4 py-3">rounded-pill</div>
           <div class="border rounded-full d-grid place-items-center p-3" style="width: 4rem; height: 4rem;">rounded-full</div>
         </div>
+      </section>
 
+      <section class="section">
         <h2>Z-index</h2>
 
         <h3>Numeric scale</h3>
@@ -2610,7 +2627,9 @@
             <tr><td><code>z-tooltip</code></td><td><code>1070</code></td><td>Tooltip</td></tr>
           </tbody>
         </table>
+      </section>
 
+      <section class="section">
         <h2>Aspect ratio</h2>
 
         <p>
@@ -2665,7 +2684,9 @@
             <p class="text-center text-sm mt-2"><code>ratio--21x9</code></p>
           </div>
         </div>
+      </section>
 
+      <section class="section">
         <h2>Grid</h2>
 
         <p>

--- a/src/js/__tests__/popover.test.js
+++ b/src/js/__tests__/popover.test.js
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { initPopover } from '../popover';
 
-const buildPopover = ({ id = 'test-pop', placement = 'bottom' } = {}) => {
+const buildPopover = ({ id = 'test-pop', placement = 'bottom', panelRect = null } = {}) => {
   const wrapper = document.createElement('div');
   wrapper.className = 'popover';
 
@@ -12,9 +12,16 @@ const buildPopover = ({ id = 'test-pop', placement = 'bottom' } = {}) => {
   wrapper.appendChild(trigger);
 
   const panel = document.createElement('div');
-  panel.className = `popover__panel popover__panel--${placement}`;
+  // Default placement is bottom; only add the modifier class for non-default placements
+  panel.className = placement === 'bottom'
+    ? 'popover__panel'
+    : `popover__panel popover__panel--${placement}`;
   panel.id = id;
   panel.hidden = true;
+
+  if (panelRect) {
+    panel.getBoundingClientRect = () => ({ bottom: 0, top: 0, left: 0, right: 0, ...panelRect });
+  }
 
   const title = document.createElement('strong');
   title.className = 'popover__title';
@@ -131,5 +138,89 @@ describe('initPopover', () => {
     expect(first.panel.hidden).toBe(true);
     expect(second.trigger.getAttribute('aria-expanded')).toBe('true');
     expect(second.panel.hidden).toBe(false);
+  });
+
+  // Viewport flip -----------------------------------------------------------
+  // jsdom default viewport: innerWidth=1024, innerHeight=768
+
+  it('flips bottom→top when the panel overflows below the viewport', () => {
+    const { trigger, panel } = buildPopover({
+      id: 'pop-flip-bt',
+      placement: 'bottom',
+      panelRect: { bottom: 780 }, // past innerHeight 768
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBe('top');
+  });
+
+  it('flips top→bottom when the panel overflows above the viewport', () => {
+    const { trigger, panel } = buildPopover({
+      id: 'pop-flip-tb',
+      placement: 'top',
+      panelRect: { top: 4 }, // less than EDGE (8)
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBe('bottom');
+  });
+
+  it('flips left→right when the panel overflows the left edge', () => {
+    const { trigger, panel } = buildPopover({
+      id: 'pop-flip-lr',
+      placement: 'left',
+      panelRect: { left: 4 }, // less than EDGE (8)
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBe('right');
+  });
+
+  it('flips right→left when the panel overflows the right edge', () => {
+    const { trigger, panel } = buildPopover({
+      id: 'pop-flip-rl',
+      placement: 'right',
+      panelRect: { right: 1030 }, // past innerWidth 1024
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBe('left');
+  });
+
+  it('does not set data-popover-flip when the panel fits', () => {
+    const { trigger, panel } = buildPopover({
+      id: 'pop-no-flip',
+      placement: 'bottom',
+      panelRect: { bottom: 400 }, // well within viewport
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBeUndefined();
+  });
+
+  it('removes data-popover-flip on close', () => {
+    const { trigger, panel } = buildPopover({
+      id: 'pop-flip-close',
+      placement: 'bottom',
+      panelRect: { bottom: 780 },
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBe('top');
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBeUndefined();
+  });
+
+  it('removes data-popover-flip when closed via Escape', () => {
+    const { wrapper, trigger, panel } = buildPopover({
+      id: 'pop-flip-esc',
+      placement: 'bottom',
+      panelRect: { bottom: 780 },
+    });
+    initPopover();
+    trigger.click();
+    expect(panel.dataset.popoverFlip).toBe('top');
+    keydown(wrapper, 'Escape');
+    expect(panel.dataset.popoverFlip).toBeUndefined();
   });
 });

--- a/src/js/__tests__/tooltip.test.js
+++ b/src/js/__tests__/tooltip.test.js
@@ -1,0 +1,143 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { initTooltip } from '../tooltip';
+
+// jsdom default viewport: innerWidth=1024, innerHeight=768
+
+const buildTooltip = ({ placement = null, text = 'Tip', top = 400, left = 400 } = {}) => {
+  const el = document.createElement('button');
+  el.className = placement ? `tooltip tooltip--${placement}` : 'tooltip';
+  el.setAttribute('data-tooltip', text);
+  document.body.appendChild(el);
+
+  // jsdom returns zeros for all rects; stub so tests can control position
+  const height = 40;
+  const width = 120;
+  el.getBoundingClientRect = () => ({
+    top,
+    left,
+    bottom: top + height,
+    right: left + width,
+    width,
+    height,
+  });
+
+  return el;
+};
+
+const mouseenter = (el) => el.dispatchEvent(new MouseEvent('mouseenter'));
+const mouseleave = (el) => el.dispatchEvent(new MouseEvent('mouseleave'));
+const focusin = (el) => el.dispatchEvent(new FocusEvent('focusin'));
+const focusout = (el) => el.dispatchEvent(new FocusEvent('focusout'));
+
+describe('initTooltip', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  it('does nothing when no tooltip elements are present', () => {
+    initTooltip();
+  });
+
+  it('ignores elements with .tooltip but no data-tooltip attribute', () => {
+    const el = document.createElement('button');
+    el.className = 'tooltip';
+    document.body.appendChild(el);
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  // Top placement (default) --------------------------------------------------
+
+  it('flips top→bottom when element is near the top edge', () => {
+    const el = buildTooltip({ top: 5 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBe('bottom');
+  });
+
+  it('does not flip when top placement has sufficient space', () => {
+    const el = buildTooltip({ top: 400 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  // Bottom placement ---------------------------------------------------------
+
+  it('flips bottom→top when element is near the bottom edge', () => {
+    // innerHeight=768; near bottom means bottom edge (top + height) close to 768
+    const el = buildTooltip({ placement: 'bottom', top: 760 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBe('top');
+  });
+
+  it('does not flip bottom placement when there is sufficient space below', () => {
+    const el = buildTooltip({ placement: 'bottom', top: 400 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  // Left placement -----------------------------------------------------------
+
+  it('flips left→right when element is near the left edge', () => {
+    const el = buildTooltip({ placement: 'left', left: 5 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBe('right');
+  });
+
+  it('does not flip left placement when there is sufficient space to the left', () => {
+    const el = buildTooltip({ placement: 'left', left: 400 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  // Right placement ----------------------------------------------------------
+
+  it('flips right→left when element is near the right edge', () => {
+    // innerWidth=1024; element right edge (left + width) close to 1024
+    const el = buildTooltip({ placement: 'right', left: 900 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBe('left');
+  });
+
+  it('does not flip right placement when there is sufficient space to the right', () => {
+    const el = buildTooltip({ placement: 'right', left: 400 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  // Cleanup ------------------------------------------------------------------
+
+  it('removes data-tooltip-flip on mouseleave', () => {
+    const el = buildTooltip({ top: 5 });
+    initTooltip();
+    mouseenter(el);
+    expect(el.dataset.tooltipFlip).toBe('bottom');
+    mouseleave(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  it('sets data-tooltip-flip on focusin and clears it on focusout', () => {
+    const el = buildTooltip({ top: 5 });
+    initTooltip();
+    focusin(el);
+    expect(el.dataset.tooltipFlip).toBe('bottom');
+    focusout(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+
+  it('does not add flip attribute when leaving without overflow', () => {
+    const el = buildTooltip({ top: 400 });
+    initTooltip();
+    mouseenter(el);
+    mouseleave(el);
+    expect(el.dataset.tooltipFlip).toBeUndefined();
+  });
+});

--- a/src/js/popover.js
+++ b/src/js/popover.js
@@ -8,10 +8,41 @@ export const initPopover = () => {
   const isOpen = (popover) =>
     getTrigger(popover)?.getAttribute('aria-expanded') === 'true';
 
+  const EDGE = 8; // minimum px clearance from viewport edge
+
+  const getPlacement = (panel) => {
+    if (panel.classList.contains('popover__panel--top')) return 'top';
+    if (panel.classList.contains('popover__panel--left')) return 'left';
+    if (panel.classList.contains('popover__panel--right')) return 'right';
+    return 'bottom';
+  };
+
+  const opposite = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' };
+
+  // Called after the panel is shown so getBoundingClientRect() returns real dimensions.
+  const applyFlip = (panel) => {
+    const placement = getPlacement(panel);
+    const rect = panel.getBoundingClientRect();
+    let overflows;
+    switch (placement) {
+      case 'bottom': overflows = rect.bottom > window.innerHeight - EDGE; break;
+      case 'top':    overflows = rect.top    < EDGE;                       break;
+      case 'left':   overflows = rect.left   < EDGE;                       break;
+      case 'right':  overflows = rect.right  > window.innerWidth  - EDGE;  break;
+      default:       overflows = false;
+    }
+    if (overflows) {
+      panel.dataset.popoverFlip = opposite[placement];
+    }
+  };
+
   const close = (popover) => {
     getTrigger(popover)?.setAttribute('aria-expanded', 'false');
     const panel = getPanel(popover);
-    if (panel) panel.hidden = true;
+    if (panel) {
+      panel.hidden = true;
+      delete panel.dataset.popoverFlip;
+    }
   };
 
   const open = (popover) => {
@@ -21,7 +52,10 @@ export const initPopover = () => {
     });
     getTrigger(popover)?.setAttribute('aria-expanded', 'true');
     const panel = getPanel(popover);
-    if (panel) panel.hidden = false;
+    if (panel) {
+      panel.hidden = false;
+      applyFlip(panel);
+    }
   };
 
   // Create the controller before attaching listeners so all of them — both

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -6,6 +6,7 @@ import { initTabs } from './tabs';
 import { initAlertClose } from './alerts';
 import { initMenuToggle } from './menuToggle';
 import { initModal } from './modal';
+import { initTooltip } from './tooltip';
 import scrollHeader from './scrollHeader';
 
 window.addEventListener('load', function () {
@@ -24,6 +25,7 @@ window.addEventListener('load', function () {
   initAlertClose();
   initMenuToggle();
   initModal();
+  initTooltip();
 
   scrollHeader();
 });

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -3,7 +3,7 @@ export const initTooltip = () => {
   if (!tooltips.length) return;
 
   const rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
-  const TOTAL = 0.75 * rootPx; // $_total: $_gap + $_arrow converted to px
+  const TOTAL = 0.66 * rootPx; // $_total: $_gap + $_arrow converted to px
   const EDGE = 8; // minimum px clearance from viewport edge
 
   const getPlacement = (el) => {

--- a/src/js/tooltip.js
+++ b/src/js/tooltip.js
@@ -1,0 +1,58 @@
+export const initTooltip = () => {
+  const tooltips = Array.from(document.querySelectorAll('.tooltip[data-tooltip]'));
+  if (!tooltips.length) return;
+
+  const rootPx = parseFloat(getComputedStyle(document.documentElement).fontSize) || 16;
+  const TOTAL = 0.75 * rootPx; // $_total: $_gap + $_arrow converted to px
+  const EDGE = 8; // minimum px clearance from viewport edge
+
+  const getPlacement = (el) => {
+    if (el.classList.contains('tooltip--bottom')) return 'bottom';
+    if (el.classList.contains('tooltip--left')) return 'left';
+    if (el.classList.contains('tooltip--right')) return 'right';
+    return 'top';
+  };
+
+  const opposite = { top: 'bottom', bottom: 'top', left: 'right', right: 'left' };
+
+  // Measure the bubble text at the same font/padding as the CSS ::before pseudo-element.
+  const measureBubble = (text) => {
+    const probe = document.createElement('span');
+    probe.setAttribute('aria-hidden', 'true');
+    probe.style.cssText =
+      'position:fixed;top:0;left:0;visibility:hidden;pointer-events:none;' +
+      'white-space:nowrap;font-size:0.875rem;line-height:1.5;padding:0.25rem 0.5rem;';
+    probe.textContent = text;
+    document.body.appendChild(probe);
+    const { width, height } = probe.getBoundingClientRect();
+    probe.remove();
+    return { width, height };
+  };
+
+  const needsFlip = (el, rect, placement) => {
+    const { width: bw, height: bh } = measureBubble(el.dataset.tooltip);
+    switch (placement) {
+      case 'top':    return rect.top    - bh - TOTAL < EDGE;
+      case 'bottom': return rect.bottom + bh + TOTAL > window.innerHeight - EDGE;
+      case 'left':   return rect.left   - bw - TOTAL < EDGE;
+      case 'right':  return rect.right  + bw + TOTAL > window.innerWidth  - EDGE;
+      default:       return false;
+    }
+  };
+
+  tooltips.forEach((el) => {
+    const show = () => {
+      const placement = getPlacement(el);
+      if (needsFlip(el, el.getBoundingClientRect(), placement)) {
+        el.dataset.tooltipFlip = opposite[placement];
+      }
+    };
+
+    const hide = () => delete el.dataset.tooltipFlip;
+
+    el.addEventListener('mouseenter', show);
+    el.addEventListener('focusin', show);
+    el.addEventListener('mouseleave', hide);
+    el.addEventListener('focusout', hide);
+  });
+};


### PR DESCRIPTION
## Summary

- **Bug fix**: Separate `svg` from the shared `img/canvas` media rule in `_reset.scss` — dropping `max-width: 100%` on SVG prevents a circular-dependency collapse in CSS grid `min-content` columns that was hiding the brand logo on desktop
- **Bug fix**: Target `.svg-inline--fa` in `_icons.scss` so Font Awesome SVG+JS-injected icons inherit `height: 1em` and don't overflow at their intrinsic 448×512 size
- **Feature**: Add `src/js/tooltip.js` — measures the tooltip bubble before display via a hidden probe element, sets `data-tooltip-flip` when it would clip the viewport; CSS attribute selectors override placement-class positions (tested in `tooltip.test.js`)
- **Feature**: Extend the same flip logic to popovers in `popover.js` — reads `getBoundingClientRect()` on the revealed panel and sets `data-popover-flip`; CSS overrides added to `_popovers.scss` (existing tests extended in `popover.test.js`)

## Test plan

- [ ] Run `yarn test` — all tests pass
- [ ] Run `yarn lint` — no lint errors
- [ ] `yarn serve` and verify the brand SVG logo is visible on desktop
- [ ] Verify the hamburger menu icon is contained within the nav button on mobile
- [ ] Hover/focus a tooltip near a viewport edge and confirm it flips to the opposite side
- [ ] Open a popover near a viewport edge and confirm it flips to the opposite side

🤖 Generated with [Claude Code](https://claude.com/claude-code)