### PR TITLE
feat: SRI hashes and versions index

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -114,10 +114,12 @@ jobs:
               -f branch=gh-pages
           fi
 
-          # Upsert versions.html (always — keeps the page template current)
+          # Upsert versions.html — always read from the default branch so
+          # re-runs against old tags (which predate versions.html) still work.
           HTML_SHA=$(gh api "repos/${REPO}/contents/versions.html?ref=gh-pages" \
             --jq '.sha' 2>/dev/null || echo '')
-          HTML_B64=$(base64 -w 0 < versions.html)
+          HTML_B64=$(gh api "repos/${REPO}/contents/versions.html" \
+            --jq '.content' | tr -d '\n')
           if [ -n "$HTML_SHA" ]; then
             gh api "repos/${REPO}/contents/versions.html" -X PUT \
               -f message="chore: update versions page" \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,6 +50,14 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Compute SRI hashes
+        id: sri
+        run: |
+          CSS_SRI="sha384-$(openssl dgst -sha384 -binary dist/css/albert.min.css | openssl base64 -A)"
+          JS_SRI="sha384-$(openssl dgst -sha384 -binary dist/js/albert.min.js | openssl base64 -A)"
+          echo "css=$CSS_SRI" >> "$GITHUB_OUTPUT"
+          echo "js=$JS_SRI" >> "$GITHUB_OUTPUT"
+
       - name: Deploy to GitHub Pages
         # Pinned to @v4 (not a commit SHA) — this is a personal project with
         # no external contributors, so the maintenance cost of SHA pinning
@@ -60,3 +68,65 @@ jobs:
           publish_dir: ./dist
           destination_dir: ${{ steps.version.outputs.version }}
           keep_files: true
+
+      - name: Update versions index
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          DATE="$(date -u +%Y-%m-%d)"
+          BASE_URL="https://albertcss.craigmcn.com"
+          REPO="${{ github.repository }}"
+
+          # Build the new entry
+          NEW_ENTRY=$(jq -nc \
+            --arg version  "$VERSION" \
+            --arg date     "$DATE" \
+            --arg css_url  "${BASE_URL}/${VERSION}/css/albert.min.css" \
+            --arg css_sri  "${{ steps.sri.outputs.css }}" \
+            --arg js_url   "${BASE_URL}/${VERSION}/js/albert.min.js" \
+            --arg js_sri   "${{ steps.sri.outputs.js }}" \
+            '{version:$version,date:$date,css:{url:$css_url,integrity:$css_sri},js:{url:$js_url,integrity:$js_sri}}')
+
+          # Read existing versions.json (or start fresh)
+          EXISTING_RESPONSE=$(gh api "repos/${REPO}/contents/versions.json?ref=gh-pages" 2>/dev/null || echo '{}')
+          EXISTING_SHA=$(echo "$EXISTING_RESPONSE" | jq -r '.sha // empty')
+          EXISTING_CONTENT=$(echo "$EXISTING_RESPONSE" | jq -r '.content // ""' \
+            | tr -d '\n' | base64 -d 2>/dev/null || echo '[]')
+
+          # Prepend new entry (dedup by version in case of re-run)
+          UPDATED=$(echo "$EXISTING_CONTENT" | jq \
+            --argjson e "$NEW_ENTRY" \
+            '[$e] + map(select(.version != $e.version))')
+          CONTENT_B64=$(printf '%s' "$UPDATED" | base64 -w 0)
+
+          # Upsert versions.json on gh-pages
+          if [ -n "$EXISTING_SHA" ]; then
+            gh api "repos/${REPO}/contents/versions.json" -X PUT \
+              -f message="chore: update versions index for ${VERSION}" \
+              -f content="$CONTENT_B64" \
+              -f sha="$EXISTING_SHA" \
+              -f branch=gh-pages
+          else
+            gh api "repos/${REPO}/contents/versions.json" -X PUT \
+              -f message="chore: create versions index" \
+              -f content="$CONTENT_B64" \
+              -f branch=gh-pages
+          fi
+
+          # Upsert versions.html (always — keeps the page template current)
+          HTML_SHA=$(gh api "repos/${REPO}/contents/versions.html?ref=gh-pages" \
+            --jq '.sha' 2>/dev/null || echo '')
+          HTML_B64=$(base64 -w 0 < versions.html)
+          if [ -n "$HTML_SHA" ]; then
+            gh api "repos/${REPO}/contents/versions.html" -X PUT \
+              -f message="chore: update versions page" \
+              -f content="$HTML_B64" \
+              -f sha="$HTML_SHA" \
+              -f branch=gh-pages
+          else
+            gh api "repos/${REPO}/contents/versions.html" -X PUT \
+              -f message="chore: add versions page" \
+              -f content="$HTML_B64" \
+              -f branch=gh-pages
+          fi

--- a/versions.html
+++ b/versions.html
@@ -1,0 +1,130 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Albert CSS — Versions</title>
+    <link
+      rel="stylesheet"
+      href="https://www.craigmcn.com/albertcss/css/albert.min.css"
+    />
+    <style>
+      .version-card + .version-card {
+        margin-top: 1.5rem;
+      }
+      .snippet-row {
+        display: grid;
+        grid-template-columns: 1fr auto;
+        gap: 0.5rem;
+        align-items: start;
+        margin-bottom: 1rem;
+      }
+      .snippet-row pre {
+        margin: 0;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-all;
+      }
+    </style>
+  </head>
+  <body>
+    <header class="header">
+      <div class="container">
+        <a class="header__brand" href="/">Albert CSS</a>
+      </div>
+    </header>
+
+    <main class="main">
+      <div class="container">
+        <h1>Version Index</h1>
+        <p>
+          Copy the <code>&lt;link&gt;</code> and
+          <code>&lt;script&gt;</code> tags to load Albert CSS from the CDN with
+          Subresource Integrity (SRI).
+        </p>
+        <div id="versions-list">
+          <p>Loading&hellip;</p>
+        </div>
+      </div>
+    </main>
+
+    <script>
+      function escapeHtml(str) {
+        return str
+          .replace(/&/g, '&amp;')
+          .replace(/</g, '&lt;')
+          .replace(/>/g, '&gt;')
+          .replace(/"/g, '&quot;');
+      }
+
+      function escapeAttr(str) {
+        return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+      }
+
+      function makeSnippets(v) {
+        const cssTag = `<link rel="stylesheet" href="${v.css.url}" integrity="${v.css.integrity}" crossorigin="anonymous">`;
+        const jsTag = `<script src="${v.js.url}" integrity="${v.js.integrity}" crossorigin="anonymous" defer><\/script>`;
+        return { cssTag, jsTag, both: cssTag + '\n' + jsTag };
+      }
+
+      function renderVersion(v, isLatest) {
+        const { cssTag, jsTag, both } = makeSnippets(v);
+        const latestBadge = isLatest
+          ? ' <span class="badge badge--primary">latest</span>'
+          : '';
+        return `<div class="card version-card">
+  <div class="card__title d-flex justify-content-between align-items-center">
+    <span><strong>${escapeHtml(v.version)}</strong>${latestBadge}</span>
+    <span class="text-muted">${escapeHtml(v.date)}</span>
+  </div>
+  <div class="card__body">
+    <p><strong>CSS</strong></p>
+    <div class="snippet-row">
+      <pre><code>${escapeHtml(cssTag)}</code></pre>
+      <button class="button button--sm" data-copy="${escapeAttr(cssTag)}">Copy</button>
+    </div>
+    <p><strong>JS</strong></p>
+    <div class="snippet-row">
+      <pre><code>${escapeHtml(jsTag)}</code></pre>
+      <button class="button button--sm" data-copy="${escapeAttr(jsTag)}">Copy</button>
+    </div>
+    <button class="button button--primary button--sm" data-copy="${escapeAttr(both)}">Copy both</button>
+  </div>
+</div>`;
+      }
+
+      const list = document.getElementById('versions-list');
+
+      list.addEventListener('click', function (e) {
+        const btn = e.target.closest('[data-copy]');
+        if (!btn) return;
+        navigator.clipboard.writeText(btn.dataset.copy).then(function () {
+          const original = btn.textContent;
+          btn.textContent = 'Copied!';
+          setTimeout(function () {
+            btn.textContent = original;
+          }, 2000);
+        });
+      });
+
+      fetch('/versions.json')
+        .then(function (r) {
+          if (!r.ok) throw new Error(r.status);
+          return r.json();
+        })
+        .then(function (versions) {
+          if (!versions.length) {
+            list.innerHTML = '<p>No versions published yet.</p>';
+            return;
+          }
+          list.innerHTML = versions
+            .map((v, i) => renderVersion(v, i === 0))
+            .join('');
+        })
+        .catch(function () {
+          list.innerHTML =
+            '<p class="text-danger">Failed to load version data.</p>';
+        });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

- Adds a **Compute SRI hashes** step to `release.yml` that generates SHA-384 integrity hashes for `albert.min.css` and `albert.min.js` immediately after the build
- Adds an **Update versions index** step that upserts `versions.json` on `gh-pages` with the new entry (idempotent — re-runs replace rather than duplicate the same version)
- Adds `versions.html` — a static page deployed to `gh-pages` root that fetches `versions.json` and renders each version with one-click copy buttons for the CSS `<link>`, JS `<script>`, and both tags together
- `versions.html` is re-deployed from source on every release, keeping the page template current with the framework

## How it works

`versions.json` accumulates entries newest-first:
```json
[
  {
    "version": "v0.16.0",
    "date": "2026-05-15",
    "css": { "url": "https://albertcss.craigmcn.com/v0.16.0/css/albert.min.css", "integrity": "sha384-..." },
    "js":  { "url": "https://albertcss.craigmcn.com/v0.16.0/js/albert.min.js",  "integrity": "sha384-..." }
  }
]
```

The page will be live at `https://albertcss.craigmcn.com/versions.html` after the next release.

## Backfilling existing versions

Re-run the release workflow manually for each existing tag to backfill `versions.json`:

Actions → Release to GitHub Pages → Run workflow → enter tag name

Tags to backfill: `0.11.0`, `0.11.3`, `0.12.0`, `0.13.0`, `v0.14.0`, `v0.15.0`

(Old tags have no `v` prefix; the workflow handles the difference.)

## Test plan

- [ ] Merge and cut a new release — verify `versions.json` is created on `gh-pages` with correct SRI hashes
- [ ] Visit `https://albertcss.craigmcn.com/versions.html` — verify the version renders with working copy buttons
- [ ] Re-run the release workflow for `v0.15.0` — verify `versions.json` is updated without duplicates
- [ ] Backfill remaining tags via `workflow_dispatch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)