### PR TITLE
fix: correctly read versions.json when absent or empty

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,16 +88,27 @@ jobs:
             --arg js_sri   "${{ steps.sri.outputs.js }}" \
             '{version:$version,date:$date,css:{url:$css_url,integrity:$css_sri},js:{url:$js_url,integrity:$js_sri}}')
 
-          # Read existing versions.json (or start fresh)
-          EXISTING_RESPONSE=$(gh api "repos/${REPO}/contents/versions.json?ref=gh-pages" 2>/dev/null || echo '{}')
-          EXISTING_SHA=$(echo "$EXISTING_RESPONSE" | jq -r '.sha // empty')
-          EXISTING_CONTENT=$(echo "$EXISTING_RESPONSE" | jq -r '.content // ""' \
-            | tr -d '\n' | base64 -d 2>/dev/null || echo '[]')
+          # Read existing versions.json from gh-pages.
+          # Use if/else so a 404 body written to stdout by `gh api` on failure
+          # never gets mixed with the fallback value.
+          if EXISTING_RESPONSE=$(gh api "repos/${REPO}/contents/versions.json?ref=gh-pages" 2>/dev/null); then
+            EXISTING_SHA=$(echo "$EXISTING_RESPONSE" | jq -r '.sha')
+            # Decode and validate; fall back to [] if content is empty or corrupt.
+            EXISTING_CONTENT=$(echo "$EXISTING_RESPONSE" | jq -r '.content' \
+              | tr -d '\n' | base64 -d | jq '.' 2>/dev/null || echo '[]')
+          else
+            EXISTING_SHA=''
+            EXISTING_CONTENT='[]'
+          fi
 
           # Prepend new entry (dedup by version in case of re-run)
           UPDATED=$(echo "$EXISTING_CONTENT" | jq \
             --argjson e "$NEW_ENTRY" \
             '[$e] + map(select(.version != $e.version))')
+          if [ -z "$UPDATED" ]; then
+            echo "Error: failed to build updated versions array" >&2
+            exit 1
+          fi
           CONTENT_B64=$(printf '%s' "$UPDATED" | base64 -w 0)
 
           # Upsert versions.json on gh-pages


### PR DESCRIPTION
## Summary

Fixes `versions.json` being written with empty content after the first two release workflow runs.

**Bug 1 — stdout contamination from `gh api` 404:**
`$(gh api ... 2>/dev/null || echo '{}')` — `gh api` writes the 404 response body to stdout before exiting non-zero. The `|| echo '{}'` then also runs, so the variable captured both concatenated. Changed to `if/else` on the API call result so the fallback is never mixed with error output.

**Bug 2 — `base64 -d` of empty input exits 0 on Linux:**
When the file doesn't exist, `.content // ""` produces `""`. On Linux, `base64 -d` of empty input succeeds (exit 0) with no output, so the `|| echo '[]'` fallback never fired. `EXISTING_CONTENT` ended up as `""`, jq silently failed, and an empty file was written. Fixed by piping decoded content through `jq '.'` for validation with a `[]` fallback — also recovers from the already-corrupt empty file on `gh-pages`.

Added an explicit `exit 1` guard if `UPDATED` is empty so future failures are visible rather than silent.

## Test plan

- [ ] Merge and re-run the release workflow for `0.11.0` via `workflow_dispatch`
- [ ] Verify `versions.json` on `gh-pages` contains a valid entry for `0.11.0`
- [ ] Run for remaining tags in order; verify entries accumulate correctly
- [ ] Visit `https://albertcss.craigmcn.com/versions.html` — verify versions render with copy buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)