### PR TITLE
fix: check base64 string for emptiness before decoding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,9 +93,15 @@ jobs:
           # never gets mixed with the fallback value.
           if EXISTING_RESPONSE=$(gh api "repos/${REPO}/contents/versions.json?ref=gh-pages" 2>/dev/null); then
             EXISTING_SHA=$(echo "$EXISTING_RESPONSE" | jq -r '.sha')
-            # Decode and validate; fall back to [] if content is empty or corrupt.
-            EXISTING_CONTENT=$(echo "$EXISTING_RESPONSE" | jq -r '.content' \
-              | tr -d '\n' | base64 -d | jq '.' 2>/dev/null || echo '[]')
+            # Extract the raw base64 string; check for emptiness before decoding.
+            # jq '.' of empty input exits 0 on Linux, so a pipeline `|| echo '[]'`
+            # fallback would never fire — check the b64 string directly instead.
+            CONTENT_B64=$(echo "$EXISTING_RESPONSE" | jq -r '.content' | tr -d '\n')
+            if [ -n "$CONTENT_B64" ]; then
+              EXISTING_CONTENT=$(printf '%s' "$CONTENT_B64" | base64 -d | jq '.' 2>/dev/null || echo '[]')
+            else
+              EXISTING_CONTENT='[]'
+            fi
           else
             EXISTING_SHA=''
             EXISTING_CONTENT='[]'


### PR DESCRIPTION
## Summary

Follow-up to #296. The `jq '.' || echo '[]'` fallback added in that PR still doesn't fire: `jq '.'` exits **0** on Linux when given empty input, so the `||` branch is never reached. `EXISTING_CONTENT` remained an empty string, causing the `jq --argjson` call to fail and `UPDATED` to be empty — triggering the "failed to build updated versions array" error on the first backfill run.

Fix: extract the raw base64 string first and check **it** for emptiness before decoding, rather than relying on any downstream command failing.

```bash
CONTENT_B64=$(echo "$EXISTING_RESPONSE" | jq -r '.content' | tr -d '\n')
if [ -n "$CONTENT_B64" ]; then
  EXISTING_CONTENT=$(printf '%s' "$CONTENT_B64" | base64 -d | jq '.' 2>/dev/null || echo '[]')
else
  EXISTING_CONTENT='[]'
fi
```

## Test plan

- [ ] Merge and re-run the release workflow for `0.11.0` via `workflow_dispatch`
- [ ] Verify `versions.json` on `gh-pages` contains a valid entry (not empty)
- [ ] Backfill remaining tags in order; verify entries accumulate correctly
- [ ] Visit `https://albertcss.craigmcn.com/versions.html` — verify all versions render

🤖 Generated with [Claude Code](https://claude.com/claude-code)