### PR TITLE
feat: style guide with snippets + gh-pages as primary home

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
           echo "css=$CSS_SRI" >> "$GITHUB_OUTPUT"
           echo "js=$JS_SRI" >> "$GITHUB_OUTPUT"
 
-      - name: Deploy to GitHub Pages
+      - name: Deploy versioned release to GitHub Pages
         # Pinned to @v4 (not a commit SHA) — this is a personal project with
         # no external contributors, so the maintenance cost of SHA pinning
         # outweighs the supply-chain benefit.
@@ -67,6 +67,13 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./dist
           destination_dir: ${{ steps.version.outputs.version }}
+          keep_files: true
+
+      - name: Deploy latest to GitHub Pages root
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist
           keep_files: true
 
       - name: Update versions index
@@ -131,31 +138,21 @@ jobs:
               -f branch=gh-pages
           fi
 
-          # Upsert index.html — always read from the default branch so
-          # re-runs against old tags (which predate index.html) still work.
-          INDEX_SHA=$(gh api "repos/${REPO}/contents/index.html?ref=gh-pages" \
+          # Upsert versions.html — always read from the default branch so
+          # re-runs against old tags still deploy the current versions page.
+          VERSIONS_SHA=$(gh api "repos/${REPO}/contents/versions.html?ref=gh-pages" \
             --jq '.sha' 2>/dev/null || echo '')
-          INDEX_B64=$(gh api "repos/${REPO}/contents/index.html" \
+          VERSIONS_B64=$(gh api "repos/${REPO}/contents/versions.html" \
             --jq '.content' | tr -d '\n')
-          if [ -n "$INDEX_SHA" ]; then
-            gh api "repos/${REPO}/contents/index.html" -X PUT \
-              -f message="chore: update version index page" \
-              -f content="$INDEX_B64" \
-              -f sha="$INDEX_SHA" \
+          if [ -n "$VERSIONS_SHA" ]; then
+            gh api "repos/${REPO}/contents/versions.html" -X PUT \
+              -f message="chore: update versions page for ${VERSION}" \
+              -f content="$VERSIONS_B64" \
+              -f sha="$VERSIONS_SHA" \
               -f branch=gh-pages
           else
-            gh api "repos/${REPO}/contents/index.html" -X PUT \
-              -f message="chore: add version index page" \
-              -f content="$INDEX_B64" \
-              -f branch=gh-pages
-          fi
-
-          # Remove legacy versions.html if still present on gh-pages
-          LEGACY_SHA=$(gh api "repos/${REPO}/contents/versions.html?ref=gh-pages" \
-            --jq '.sha' 2>/dev/null || echo '')
-          if [ -n "$LEGACY_SHA" ]; then
-            gh api "repos/${REPO}/contents/versions.html" -X DELETE \
-              -f message="chore: remove legacy versions.html (replaced by index.html)" \
-              -f sha="$LEGACY_SHA" \
+            gh api "repos/${REPO}/contents/versions.html" -X PUT \
+              -f message="chore: add versions page" \
+              -f content="$VERSIONS_B64" \
               -f branch=gh-pages
           fi

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,6 +1,7 @@
 import gulp from 'gulp';
 import gulpif from 'gulp-if';
 import parseArgs from 'minimist';
+import { Transform } from 'stream';
 import * as sassInit from 'sass';
 import gulpSass from 'gulp-sass';
 import autoprefixer from 'gulp-autoprefixer';
@@ -120,9 +121,38 @@ gulp.task('js-min', function () {
 });
 
 // HTML
+function stripSnippets() {
+  return new Transform({
+    objectMode: true,
+    transform(file, _, callback) {
+      if (file.isBuffer()) {
+        let html = file.contents.toString('utf8');
+        // Remove <details class="sg-snippet">…</details> elements
+        html = html.replace(
+          /[ \t]*<details class="sg-snippet">[\s\S]*?<\/details>\n?/g,
+          '',
+        );
+        // Remove the dead /* ---- Code snippets ---- */ CSS block
+        html = html.replace(
+          /\n      \/\* ---- Code snippets ---- \*\/[\s\S]*?(?=\n\n      \/\*)/,
+          '',
+        );
+        // Remove the dead copy-button JS block
+        html = html.replace(
+          /\n\n      \/\/ Copy buttons\n      document\.querySelectorAll\('\.sg-snippet__copy'\)[\s\S]*?\}\);\n/,
+          '\n',
+        );
+        file.contents = Buffer.from(html, 'utf8');
+      }
+      callback(null, file);
+    },
+  });
+}
+
 gulp.task('html', function () {
   return gulp
     .src('./src/**/*.html')
+    .pipe(gulpif(env === 'netlify', stripSnippets()))
     .pipe(gulp.dest(output[env]))
     .pipe(gulpif(env === 'netlify', gulp.dest(outputNetlify)));
 });

--- a/src/css/albert.scss
+++ b/src/css/albert.scss
@@ -8,8 +8,10 @@
 
 // Layouts
 @use 'scss/layouts/header';
+@use 'scss/layouts/container';
 @use 'scss/layouts/main';
 @use 'scss/layouts/sections';
+@use 'scss/layouts/sidebar-layout';
 @use 'scss/layouts/toolbar';
 
 // Components

--- a/src/css/scss/layouts/_container.scss
+++ b/src/css/scss/layouts/_container.scss
@@ -1,0 +1,82 @@
+@use '../variables' as *;
+@use '../mixins' as *;
+
+/**
+ * Containers
+ *
+ * Bootstrap 5-compatible responsive containers.
+ * Replaces .main / .main--fixed (deprecated).
+ *
+ * .container       — fluid at xs; constrained at sm and above
+ * .container-sm    — same as .container
+ * .container-md    — fluid below md; constrained from md up
+ * .container-lg    — fluid below lg; constrained from lg up
+ * .container-xl    — fluid below xl; constrained at xl only
+ * .container-fluid — always 100% wide
+ */
+
+$container-max-sm: 540px;
+$container-max-md: 720px;
+$container-max-lg: 960px;
+$container-max-xl: 1140px;
+
+.container,
+.container-sm,
+.container-md,
+.container-lg,
+.container-xl,
+.container-fluid {
+  width: 100%;
+  padding-inline: $spacing;
+  margin-inline: auto;
+  margin-block-start: $spacing;
+}
+
+.container,
+.container-sm {
+  @include layout-sm {
+    max-width: $container-max-sm;
+  }
+
+  @include layout-md {
+    max-width: $container-max-md;
+  }
+
+  @include layout-lg {
+    max-width: $container-max-lg;
+  }
+
+  @include layout-xl {
+    max-width: $container-max-xl;
+  }
+}
+
+.container-md {
+  @include layout-md {
+    max-width: $container-max-md;
+  }
+
+  @include layout-lg {
+    max-width: $container-max-lg;
+  }
+
+  @include layout-xl {
+    max-width: $container-max-xl;
+  }
+}
+
+.container-lg {
+  @include layout-lg {
+    max-width: $container-max-lg;
+  }
+
+  @include layout-xl {
+    max-width: $container-max-xl;
+  }
+}
+
+.container-xl {
+  @include layout-xl {
+    max-width: $container-max-xl;
+  }
+}

--- a/src/css/scss/layouts/_main.scss
+++ b/src/css/scss/layouts/_main.scss
@@ -1,8 +1,11 @@
 @use '../variables' as *;
 
 /**
-  * Main
-  */
+ * Main (deprecated)
+ *
+ * Use .container / .container-{sm|md|lg|xl|fluid} instead.
+ * These classes are kept for backwards compatibility and will be removed in a future version.
+ */
 
 .main {
   margin: $spacing auto 0 auto;

--- a/src/css/scss/layouts/_sections.scss
+++ b/src/css/scss/layouts/_sections.scss
@@ -23,6 +23,17 @@
   }
 }
 
+/**
+ * sections--divided adds a top border between adjacent sections.
+ * Prefer this over sections--alternating inside constrained layouts
+ * (e.g. alongside a sidebar) where the full-bleed ::before trick breaks.
+ */
+.sections--divided {
+  > .section + .section {
+    border-top: 1px solid var(--grey200);
+  }
+}
+
 .sections--alternating {
   > .section:nth-of-type(even)::before {
     background-color: var(--sectionAltBg);

--- a/src/css/scss/layouts/_sidebar-layout.scss
+++ b/src/css/scss/layouts/_sidebar-layout.scss
@@ -1,0 +1,30 @@
+@use '../mixins' as *;
+
+/**
+ * Sidebar layout
+ *
+ * Two-column grid: a fixed-width aside and a flexible main column.
+ * Override the sidebar width with --layout-sidebar-width on the element.
+ * On small screens the columns stack vertically; consumers may hide the
+ * aside column at small sizes with a responsive display utility.
+ *
+ * Usage:
+ *   <div class="layout-sidebar">
+ *     <aside>...</aside>
+ *     <main>...</main>
+ *   </div>
+ */
+
+.layout-sidebar {
+  display: grid;
+  grid-template-columns: 1fr;
+  align-items: start;
+
+  @include layout-md {
+    grid-template-columns: var(--layout-sidebar-width, 15rem) 1fr;
+  }
+
+  > * {
+    min-width: 0;
+  }
+}

--- a/src/index.html
+++ b/src/index.html
@@ -58,6 +58,189 @@
       crossorigin="anonymous"
       defer
     ></script>
+
+    <style>
+      /* ---- Style guide layout ---- */
+      html {
+        scroll-padding-top: var(
+          --headerHeight,
+          57px
+        ); /* height of sticky header */
+      }
+
+      @media (prefers-reduced-motion: no-preference) {
+        html {
+          scroll-behavior: smooth;
+        }
+      }
+
+      /* ---- Style guide sidebar width override ---- */
+      .layout-sidebar {
+        --layout-sidebar-width: 12.5rem;
+      }
+
+      .sg-nav {
+        position: sticky;
+        top: var(--headerHeight, 57px);
+        max-height: calc(100vh - var(--headerHeight, 57px));
+        overflow-y: auto;
+        padding: 1rem 0;
+        border-inline-end: 1px solid var(--grey200);
+      }
+
+      .sg-content {
+        margin-inline: 2rem;
+      }
+
+      /* ---- Side nav ---- */
+      .sg-nav__list,
+      .sg-nav__sub {
+        list-style: none;
+        padding: 0;
+        margin: 0;
+      }
+
+      .sg-nav__link {
+        --sg-nav-link-color: var(--body-text-color);
+        display: block;
+        padding: 0.2rem 0.75rem;
+        margin-inline: 0.25rem;
+        font-size: 0.875rem;
+        color: var(--sg-nav-link-color);
+        text-decoration: none;
+        line-height: 1.3;
+        border-inline-start: 3px solid transparent;
+        transition:
+          color 0.15s,
+          border-color 0.15s;
+      }
+
+      .sg-nav__link:hover,
+      .sg-nav__link:focus-visible {
+        color: var(--primary);
+      }
+
+      .sg-nav__link:focus {
+        box-shadow: none;
+      }
+
+      .sg-nav__link:focus-visible {
+        border-radius: 0.125rem;
+        outline: 2px solid color-mix(in srgb, var(--primary) 80%, white);
+        outline-offset: 1px;
+      }
+
+      .sg-nav__link:visited {
+        color: var(--sg-nav-link-color);
+      }
+
+      .sg-nav__link.is-active {
+        color: var(--primary);
+        font-weight: 600;
+        border-inline-start-color: var(--primary);
+      }
+
+      .sg-nav__sub {
+        padding-inline-start: 0.75rem;
+        margin-block-end: 0.25rem;
+      }
+
+      .sg-nav__sub .sg-nav__link {
+        font-size: 0.875rem;
+        padding-block: 0.25rem;
+      }
+
+      .sg-nav__group {
+        display: block;
+        padding: 0.5rem 1rem 0.15rem;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: var(--colorMuted);
+        margin-block-start: 0.5rem;
+      }
+
+      /* ---- Code snippets ---- */
+      .sg-snippet {
+        margin-block-start: 1rem;
+        border: 1px solid var(--grey200);
+        border-radius: 0.375rem;
+        overflow: hidden;
+      }
+
+      .sg-snippet > summary {
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0.4rem 0.75rem;
+        font-size: 0.75rem;
+        color: var(--colorMuted);
+        user-select: none;
+        background: var(--grey100);
+        list-style: none;
+      }
+
+      .sg-snippet > summary::marker,
+      .sg-snippet > summary::-webkit-details-marker {
+        display: none;
+      }
+
+      .sg-snippet[open] > summary {
+        border-block-end: 1px solid var(--grey200);
+      }
+
+      .sg-snippet__chevron {
+        flex-shrink: 0;
+        transition: transform 0.2s ease;
+      }
+
+      .sg-snippet[open] > summary .sg-snippet__chevron {
+        transform: rotate(90deg);
+      }
+
+      .sg-snippet__code {
+        position: relative;
+      }
+
+      .sg-snippet__copy {
+        position: absolute;
+        inset-block-start: 0.5rem;
+        inset-inline-end: 0.5rem;
+        z-index: 1;
+        opacity: 0;
+        transition: opacity 0.15s;
+      }
+
+      .sg-snippet__code:hover .sg-snippet__copy,
+      .sg-snippet__copy:focus-visible {
+        opacity: 1;
+      }
+
+      .sg-snippet__code pre {
+        margin: 0;
+        padding: 1rem;
+        overflow-x: auto;
+        font-size: 0.8rem;
+        tab-size: 2;
+      }
+
+      .sg-snippet__code code {
+        background: none;
+        padding: 0;
+        border: none;
+        border-radius: 0;
+        font-size: inherit;
+      }
+
+      /* ---- Responsive ---- */
+      @media (max-width: 767px) {
+        .sg-nav {
+          display: none;
+        }
+      }
+    </style>
   </head>
 
   <body>
@@ -149,3020 +332,4133 @@
       </button>
     </header>
 
-    <main class="main main--fixed sections--alternating">
-      <section class="section">
-        <h1>Colours</h1>
-        <div class="flex flex--grid">
-          <div
-            class="card flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Default</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #222<br />
-                rgb(34, 34, 34)<br />
-                hsl(0, 0%, 13%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #fff<br />
-                rgb(255, 255, 255)<br />
-                hsl(0, 0%, 100%)
-              </p>
-            </div>
-          </div>
-
-          <div
-            class="card card--primary flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Primary</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #005b99<br />
-                rgb(0, 91, 153)<br />
-                hsl(204, 100%, 30%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #4cb5fa<br />
-                rgb(76, 181, 250)<br />
-                hsl(204, 95%, 64%)
-              </p>
-            </div>
-          </div>
-
-          <div
-            class="card card--secondary flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Secondary</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #993d00<br />
-                rgb(153, 61, 0)<br />
-                hsl(24, 100%, 30%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #fa924c<br />
-                rgb(250, 146, 76)<br />
-                hsl(24, 95%, 64%)
-              </p>
-            </div>
-          </div>
-
-          <div
-            class="card card--info flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Information</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #03607d<br />
-                rgb(3, 96, 125)<br />
-                hsl(194, 95%, 25%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #0bbaef<br />
-                gb(11, 186, 239)<br />
-                hsl(194, 91%, 49%)
-              </p>
-            </div>
-          </div>
-
-          <div
-            class="card card--success flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Success</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #036803<br />
-                rgb(3, 104, 3)<br />
-                hsl(120, 94%, 21%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #09c809<br />
-                rgb(9, 200, 9)<br />
-                hsl(120, 91%, 41%)
-              </p>
-            </div>
-          </div>
-
-          <div
-            class="card card--warning flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Warning</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #695802<br />
-                rgb(105, 88, 2)<br />
-                hsl(50, 96%, 21%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #f9d615<br />
-                rgb(249, 214, 21)<br />
-                hsl(51, 95%, 53%)
-              </p>
-            </div>
-          </div>
-
-          <div
-            class="card card--danger flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Danger</h2>
-            </div>
-            <div class="card__body" data-color="light">
-              <p>
-                #b60202<br />
-                rgb(182, 2, 2)<br />
-                hsl(0, 98%, 36%)
-              </p>
-            </div>
-            <div class="card__body d-none" data-color="dark">
-              <p>
-                #f49090<br />
-                rgb(244, 144, 144)<br />
-                hsl(0, 82%, 76%)
-              </p>
-            </div>
-          </div>
-        </div>
-
-        <h2>Dark mode</h2>
-
-        <p>
-          A dark mode is available by adding <code>data-mode="dark"</code> to
-          the <code>&lt;html&gt;</code> tag or
-          <code>class="theme--dark"</code> to the <code>&lt;body&gt;</code> tag.
-        </p>
-
-        <p>
-          <button
-            class="button"
-            type="button"
-            data-mode="dark"
-            data-toggle-dark-mode
-          >
-            Toggle <span class="px-1" data-color="light">dark</span
-            ><span class="d-none px-1" data-color="dark">light</span> mode
-          </button>
-        </p>
-      </section>
-
-      <section class="section">
-        <h1>Typography</h1>
-
-        <h2>Headings</h2>
-
-        <h1>Heading 1 <span class="subheading">Sub-heading</span></h1>
-        <h2>Heading 2 <span class="subheading">Sub-heading</span></h2>
-        <h3>Heading 3 <span class="subheading">Sub-heading</span></h3>
-        <h4>Heading 4 <span class="subheading">Sub-heading</span></h4>
-        <h5>Heading 5 <span class="subheading">Sub-heading</span></h5>
-        <h6>Heading 6 <span class="subheading">Sub-heading</span></h6>
-
-        <h2>Paragraphs</h2>
-
-        <p>
-          <span class="lede">Paragraph lorem ipsum dolor sit amet,</span>
-          consectetur adipiscing elit. Nulla tempus massa eu est ullamcorper,
-          luctus pellentesque leo molestie. Etiam ipsum magna, egestas ac massa
-          gravida, condimentum scelerisque leo.
-        </p>
-
-        <p>
-          You can add a <code>&lt;span class="lede"/&gt;</code> for emphasis of
-          the first part of a paragraph.
-        </p>
-
-        <p>
-          Maecenas commodo malesuada eros vitae pellentesque. In suscipit
-          finibus molestie. Sed in ultricies dolor. Vivamus quis varius nisl, at
-          fringilla felis. Sed faucibus ullamcorper arcu in commodo. Cras
-          euismod lacus id volutpat porta. Etiam vel posuere enim, eu accumsan
-          sem. Mauris ante purus, mattis quis ante vel, iaculis mattis nulla.
-          Donec finibus sem nec dictum vestibulum. Sed vitae augue quis ligula
-          efficitur fermentum non eu nulla. Proin tincidunt ullamcorper blandit.
-        </p>
-        <p>
-          Pellentesque efficitur et orci nec lacinia. Integer congue justo in
-          libero eleifend ullamcorper. Nullam rutrum, lorem eget efficitur
-          placerat, turpis libero faucibus est, at aliquam arcu justo sit amet
-          nibh. Sed mollis enim tristique tortor pulvinar bibendum. Nullam vel
-          maximus dolor, at ornare velit. Nunc efficitur elit at felis pulvinar,
-          vel fermentum justo gravida. Proin volutpat quam neque, in porta elit
-          cursus at. Nam id velit semper, finibus sem id, fermentum sapien.
-          Aliquam lobortis nisl a libero fringilla sollicitudin.
-        </p>
-
-        <h2>Links</h2>
-
-        <h2><a href="#">Heading 2 link</a></h2>
-        <h3><a href="#">Heading 3 link</a></h3>
-
-        <p>
-          Lorem ipsum dolor <a href="#">sit amet,</a> consectetur adipiscing
-          elit.
-        </p>
-        <p>
-          Nulla tempus <a href="#">massa eu est</a> ullamcorper, luctus
-          pellentesque leo molestie.
-        </p>
-        <p>
-          Etiam ipsum magna,
-          <a href="#">egestas ac massa gravida,</a> condimentum scelerisque leo.
-        </p>
-
-        <p>
-          Remove <code>:hover</code>, <code>:active</code> and
-          <code>:visited</code> styles by adding the
-          <code>permanent</code> class.
-        </p>
-
-        <p>
-          Lorem ipsum dolor
-          <a href="#" class="permanent">sit amet,</a> consectetur adipiscing
-          elit.
-        </p>
-
-        <h2>Text variants</h2>
-
-        <p class="text-primary">
-          Primary lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-
-        <p class="text-secondary">
-          Secondary lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-
-        <p class="text-info">
-          Information lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-
-        <p class="text-success">
-          Success lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-
-        <p class="text-warning">
-          Warning lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-
-        <p class="text-danger">
-          Danger lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-
-        <p class="text-muted">
-          Muted lorem ipsum dolor sit amet, consectetur adipiscing elit.
-        </p>
-      </section>
-
-      <section class="section">
-        <h1>Tables</h1>
-
-        <h2>Base</h2>
-
-        <table class="table">
-          <caption>
-            Table caption
-          </caption>
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Department</th>
-              <th>Role</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Alice Smith</td>
-              <td>Engineering</td>
-              <td>Developer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Bob Jones</td>
-              <td>Design</td>
-              <td>Designer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Carol White</td>
-              <td>Marketing</td>
-              <td>Manager</td>
-              <td>On leave</td>
-            </tr>
-            <tr>
-              <td>David Brown</td>
-              <td>Finance</td>
-              <td>Analyst</td>
-              <td>Active</td>
-            </tr>
-          </tbody>
-          <tfoot>
-            <tr>
-              <td colspan="4">4 team members</td>
-            </tr>
-          </tfoot>
-        </table>
-
-        <h2>Striped</h2>
-
-        <table class="table table--striped">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Department</th>
-              <th>Role</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Alice Smith</td>
-              <td>Engineering</td>
-              <td>Developer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Bob Jones</td>
-              <td>Design</td>
-              <td>Designer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Carol White</td>
-              <td>Marketing</td>
-              <td>Manager</td>
-              <td>On leave</td>
-            </tr>
-            <tr>
-              <td>David Brown</td>
-              <td>Finance</td>
-              <td>Analyst</td>
-              <td>Active</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Bordered</h2>
-
-        <table class="table table--bordered">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Department</th>
-              <th>Role</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Alice Smith</td>
-              <td>Engineering</td>
-              <td>Developer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Bob Jones</td>
-              <td>Design</td>
-              <td>Designer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Carol White</td>
-              <td>Marketing</td>
-              <td>Manager</td>
-              <td>On leave</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Hover</h2>
-
-        <table class="table table--hover">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Department</th>
-              <th>Role</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Alice Smith</td>
-              <td>Engineering</td>
-              <td>Developer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Bob Jones</td>
-              <td>Design</td>
-              <td>Designer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Carol White</td>
-              <td>Marketing</td>
-              <td>Manager</td>
-              <td>On leave</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Small</h2>
-
-        <table class="table table--sm">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Department</th>
-              <th>Role</th>
-              <th>Status</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>Alice Smith</td>
-              <td>Engineering</td>
-              <td>Developer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Bob Jones</td>
-              <td>Design</td>
-              <td>Designer</td>
-              <td>Active</td>
-            </tr>
-            <tr>
-              <td>Carol White</td>
-              <td>Marketing</td>
-              <td>Manager</td>
-              <td>On leave</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h2>Responsive</h2>
-
-        <p>
-          Wrap in <code>.table-responsive</code> to enable horizontal scroll on
-          narrow viewports.
-        </p>
-
-        <div class="table-responsive">
-          <table class="table table--bordered">
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Email</th>
-                <th>Department</th>
-                <th>Role</th>
-                <th>Location</th>
-                <th>Start date</th>
-                <th>Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              <tr>
-                <td>Alice Smith</td>
-                <td>alice@example.com</td>
-                <td>Engineering</td>
-                <td>Developer</td>
-                <td>Toronto</td>
-                <td>2021-03-15</td>
-                <td>Active</td>
-              </tr>
-              <tr>
-                <td>Bob Jones</td>
-                <td>bob@example.com</td>
-                <td>Design</td>
-                <td>Designer</td>
-                <td>Vancouver</td>
-                <td>2019-11-01</td>
-                <td>Active</td>
-              </tr>
-              <tr>
-                <td>Carol White</td>
-                <td>carol@example.com</td>
-                <td>Marketing</td>
-                <td>Manager</td>
-                <td>Montreal</td>
-                <td>2018-06-20</td>
-                <td>On leave</td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      </section>
-
-      <section class="section">
-        <h1>Forms</h1>
-
-        <form class="form">
-          <div class="form__group">
-            <label class="form__label form__label--lg">Input large label</label>
-            <input class="form__control form__control--lg" type="text" />
-            <p class="text-muted text-sm">Some help text for this input.</p>
-          </div>
-
-          <div class="form__group">
-            <label class="form__label">Input label</label>
-            <input class="form__control" type="text" required />
-          </div>
-
-          <div class="form__group">
-            <label class="form__label form__label--sm">Input label small</label>
-            <input
-              class="form__control form__control--sm"
-              type="text"
-              required
-            />
-          </div>
-
-          <div class="form__group">
-            <label class="form__label">Select label</label>
-            <select
-              id="select-control"
-              name="select_control"
-              class="form__control"
-              required
-            >
-              <option value="">Select</option>
-              <option value="1">Option 1</option>
-              <option value="2">Option 2</option>
-            </select>
-          </div>
-
-          <fieldset class="form__group">
-            <legend class="form__label">Checkbox group</legend>
-            <div id="checkbox-error"></div>
-            <div class="form__check">
-              <label
-                ><input
-                  type="checkbox"
-                  name="checkbox[]"
-                  required
-                  data-bouncer-target="#checkbox-error"
-                />
-                Checkbox input</label
+    <main class="container">
+      <div class="layout-sidebar">
+        <nav class="sg-nav" aria-label="Contents">
+          <ul class="sg-nav__list">
+            <li><a class="sg-nav__link" href="#colours">Colours</a></li>
+            <li><a class="sg-nav__link" href="#typography">Typography</a></li>
+            <li><a class="sg-nav__link" href="#tables">Tables</a></li>
+            <li><a class="sg-nav__link" href="#forms">Forms</a></li>
+            <li><a class="sg-nav__link" href="#buttons">Buttons</a></li>
+            <li><a class="sg-nav__link" href="#alerts">Alerts</a></li>
+            <li><a class="sg-nav__link" href="#lists">Lists</a></li>
+            <li><a class="sg-nav__link" href="#cards">Cards</a></li>
+            <li><a class="sg-nav__link" href="#images">Images</a></li>
+            <li><a class="sg-nav__link" href="#badges">Badges</a></li>
+            <li><a class="sg-nav__link" href="#modals">Modals</a></li>
+            <li><a class="sg-nav__link" href="#accordion">Accordion</a></li>
+            <li><a class="sg-nav__link" href="#tabs">Tabs</a></li>
+            <li><a class="sg-nav__link" href="#dropdowns">Dropdowns</a></li>
+            <li>
+              <a class="sg-nav__link" href="#tooltips-popovers"
+                >Tooltips &amp; Popovers</a
               >
-            </div>
-            <div class="form__check">
-              <label
-                ><input
-                  type="checkbox"
-                  name="checkbox[]"
-                  required
-                  data-bouncer-target="#checkbox-error"
-                />
-                Checkbox input</label
+            </li>
+            <li>
+              <span class="sg-nav__group">Utilities</span>
+              <ul class="sg-nav__sub">
+                <li><a class="sg-nav__link" href="#spacing">Spacing</a></li>
+                <li><a class="sg-nav__link" href="#text">Text</a></li>
+                <li><a class="sg-nav__link" href="#display">Display</a></li>
+                <li><a class="sg-nav__link" href="#overflow">Overflow</a></li>
+                <li><a class="sg-nav__link" href="#position">Position</a></li>
+                <li><a class="sg-nav__link" href="#shadows">Shadows</a></li>
+                <li><a class="sg-nav__link" href="#borders">Borders</a></li>
+                <li><a class="sg-nav__link" href="#z-index">Z-index</a></li>
+                <li>
+                  <a class="sg-nav__link" href="#aspect-ratio">Aspect ratio</a>
+                </li>
+                <li><a class="sg-nav__link" href="#grid">Grid</a></li>
+              </ul>
+            </li>
+            <li>
+              <a
+                class="sg-nav__link"
+                href="https://albertcss.craigmcn.com/versions.html"
+                >Version history</a
               >
-            </div>
-          </fieldset>
+            </li>
+          </ul>
+        </nav>
 
-          <fieldset class="form__group">
-            <legend class="form__label">Radio group</legend>
-            <div id="radio-error"></div>
-            <div class="form__check">
-              <label
-                ><input
-                  type="radio"
-                  name="radio"
-                  required
-                  data-bouncer-target="#radio-error"
-                />
-                Radio input</label
+        <div class="sg-content sections--divided">
+          <section id="colours" class="section">
+            <h1>Colours</h1>
+            <div class="flex flex--grid">
+              <div
+                class="card flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
               >
-            </div>
-            <div class="form__check">
-              <label
-                ><input
-                  type="radio"
-                  name="radio"
-                  required
-                  data-bouncer-target="#radio-error"
-                />
-                Radio input</label
+                <div class="card__title">
+                  <h2>Default</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #222<br />
+                    rgb(34, 34, 34)<br />
+                    hsl(0, 0%, 13%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #fff<br />
+                    rgb(255, 255, 255)<br />
+                    hsl(0, 0%, 100%)
+                  </p>
+                </div>
+              </div>
+
+              <div
+                class="card card--primary flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
               >
+                <div class="card__title">
+                  <h2>Primary</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #005b99<br />
+                    rgb(0, 91, 153)<br />
+                    hsl(204, 100%, 30%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #4cb5fa<br />
+                    rgb(76, 181, 250)<br />
+                    hsl(204, 95%, 64%)
+                  </p>
+                </div>
+              </div>
+
+              <div
+                class="card card--secondary flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Secondary</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #993d00<br />
+                    rgb(153, 61, 0)<br />
+                    hsl(24, 100%, 30%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #fa924c<br />
+                    rgb(250, 146, 76)<br />
+                    hsl(24, 95%, 64%)
+                  </p>
+                </div>
+              </div>
+
+              <div
+                class="card card--info flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Information</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #03607d<br />
+                    rgb(3, 96, 125)<br />
+                    hsl(194, 95%, 25%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #0bbaef<br />
+                    gb(11, 186, 239)<br />
+                    hsl(194, 91%, 49%)
+                  </p>
+                </div>
+              </div>
+
+              <div
+                class="card card--success flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Success</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #036803<br />
+                    rgb(3, 104, 3)<br />
+                    hsl(120, 94%, 21%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #09c809<br />
+                    rgb(9, 200, 9)<br />
+                    hsl(120, 91%, 41%)
+                  </p>
+                </div>
+              </div>
+
+              <div
+                class="card card--warning flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Warning</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #695802<br />
+                    rgb(105, 88, 2)<br />
+                    hsl(50, 96%, 21%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #f9d615<br />
+                    rgb(249, 214, 21)<br />
+                    hsl(51, 95%, 53%)
+                  </p>
+                </div>
+              </div>
+
+              <div
+                class="card card--danger flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Danger</h2>
+                </div>
+                <div class="card__body" data-color="light">
+                  <p>
+                    #b60202<br />
+                    rgb(182, 2, 2)<br />
+                    hsl(0, 98%, 36%)
+                  </p>
+                </div>
+                <div class="card__body d-none" data-color="dark">
+                  <p>
+                    #f49090<br />
+                    rgb(244, 144, 144)<br />
+                    hsl(0, 82%, 76%)
+                  </p>
+                </div>
+              </div>
             </div>
-          </fieldset>
 
-          <div class="form__group">
-            <label class="form__label">Input label</label>
-            <input
-              class="form__control form__control--file"
-              type="file"
-              required
-            />
-          </div>
-
-          <div class="form__group">
-            <button class="button">Submit</button>
-          </div>
-        </form>
-
-        <h2>Inline</h2>
-
-        <p>
-          <code>.form--inline</code> class can be used to display form controls
-          inline. On smaller screens, the controls will wrap to the next line.
-        </p>
-
-        <form class="form form--inline">
-          <div class="form__group">
-            <label class="form__label">Input label</label>
-            <input class="form__control" type="text" />
-          </div>
-
-          <div class="form__group">
-            <label class="form__label visually-hidden">Select label</label>
-            <select
-              id="select-control-2"
-              name="select_control_2"
-              class="form__control"
-            >
-              <option value="">Select</option>
-              <option value="1">Option 1</option>
-              <option value="2">Option 2</option>
-            </select>
-          </div>
-
-          <div class="form__group">
-            <button class="button">Submit</button>
-          </div>
-        </form>
-
-        <form class="form form--inline">
-          <div class="form__group">
-            <label class="form__label">Input label</label>
-            <input class="form__control form__control--lg" type="text" />
-          </div>
-
-          <div class="form__group">
-            <label class="form__label visually-hidden">Select label</label>
-            <select
-              id="select-control-2"
-              name="select_control_2"
-              class="form__control form__control--lg"
-            >
-              <option value="">Select</option>
-              <option value="1">Option 1</option>
-              <option value="2">Option 2</option>
-            </select>
-          </div>
-
-          <div class="form__group">
-            <button class="button button--lg">Submit</button>
-          </div>
-        </form>
-      </section>
-
-      <section class="section">
-        <h1>Buttons</h1>
-
-        <p>
-          Button classes can be applied to <code>&lt;a&gt;</code>,
-          <code>&lt;button&gt;</code> or
-          <code>&lt;input type="button|submit|reset"&gt;</code> tags.
-        </p>
-
-        <p>
-          <button class="button">Default</button>
-          <button class="button button--primary">Primary</button>
-          <button class="button button--secondary">Secondary</button>
-          <button class="button button--info">Info</button>
-          <button class="button button--success">Success</button>
-          <button class="button button--warning">Warning</button>
-          <button class="button button--danger">Danger</button>
-          <a href="#" class="button button--link">Link</a>
-        </p>
-
-        <p>Buttons also come in a <code>-dark</code> variant.</p>
-
-        <p>
-          <button class="button button--dark">Default</button>
-          <button class="button button--primary-dark">Primary</button>
-          <button class="button button--secondary-dark">Secondary</button>
-          <button class="button button--info-dark">Info</button>
-          <button class="button button--success-dark">Success</button>
-          <button class="button button--warning-dark">Warning</button>
-          <button class="button button--danger-dark">Danger</button>
-        </p>
-
-        <p>
-          Buttons also come in three sizes: default, <code>button--sm</code> and
-          <code>button--lg</code>.
-        </p>
-
-        <p><button class="button button--lg">Large</button></p>
-        <p><button class="button button--primary">Default</button></p>
-        <p>
-          <button class="button button--secondary button--sm">Small</button>
-        </p>
-
-        <h2>Button groups</h2>
-
-        <p>
-          Wrap <code>.button</code> elements in a <code>.button-group</code> to
-          connect them into a single control. Buttons share borders and the
-          group has a continuous border-radius on its outer edges.
-        </p>
-
-        <div>
-          <div class="button-group" role="group" aria-label="Text formatting">
-            <button class="button">Default</button>
-            <button class="button">Middle</button>
-            <button class="button">Right</button>
-          </div>
-        </div>
-
-        <div>
-          <div class="button-group" role="group" aria-label="Primary actions">
-            <button class="button button--primary">Left</button>
-            <button class="button button--primary">Middle</button>
-            <button class="button button--primary">Right</button>
-          </div>
-        </div>
-
-        <p>Mixed variants work too:</p>
-
-        <div>
-          <div class="button-group" role="group" aria-label="Mixed">
-            <button class="button button--success">Save</button>
-            <button class="button button--warning">Draft</button>
-            <button class="button button--danger">Delete</button>
-          </div>
-        </div>
-
-        <h3>Radio button group</h3>
-
-        <p>
-          Place a <code>.button-group__input</code> input immediately before its
-          label. The input is visually hidden; the checked state fills the label
-          with the variant colour.
-        </p>
-
-        <div class="button-group" role="group" aria-label="Text alignment">
-          <input
-            class="button-group__input"
-            type="radio"
-            id="align-start"
-            name="align"
-            checked
-          />
-          <label class="button button--primary" for="align-start">Left</label>
-          <input
-            class="button-group__input"
-            type="radio"
-            id="align-center"
-            name="align"
-          />
-          <label class="button button--primary" for="align-center"
-            >Centre</label
-          >
-          <input
-            class="button-group__input"
-            type="radio"
-            id="align-end"
-            name="align"
-          />
-          <label class="button button--primary" for="align-end">Right</label>
-        </div>
-
-        <h3>Checkbox button group</h3>
-
-        <p>Same pattern with <code>type="checkbox"</code> for multi-select:</p>
-
-        <div class="button-group" role="group" aria-label="Text style">
-          <input
-            class="button-group__input"
-            type="checkbox"
-            id="style-bold"
-            name="style-bold"
-          />
-          <label class="button button--secondary" for="style-bold">Bold</label>
-          <input
-            class="button-group__input"
-            type="checkbox"
-            id="style-italic"
-            name="style-italic"
-            checked
-          />
-          <label class="button button--secondary" for="style-italic"
-            >Italic</label
-          >
-          <input
-            class="button-group__input"
-            type="checkbox"
-            id="style-underline"
-            name="style-underline"
-          />
-          <label class="button button--secondary" for="style-underline"
-            >Underline</label
-          >
-        </div>
-      </section>
-
-      <section class="section">
-        <h1>Alerts</h1>
-
-        <p>
-          Alerts come in a few flavours: default, information (info), success,
-          warning and error. Links within the message will inherit the alert
-          text colour, losing the hover, active and visited states.
-        </p>
-
-        <p>Alerts with an <code>alert__close</code> button:</p>
-        <blockquote>
-          <pre><code>&lt;button type="button" class="alert__close" aria-label="Close"&gt;&lt;span class="fa-light fa-xl fa-xmark"&gt;&lt;/i&gt;&lt;/button&gt;</code></pre>
-        </blockquote>
-
-        <p>
-          will be hidden (<code>display: none;</code>) when closed. Alerts with
-          the <code>alert--removable</code> class will be removed from the DOM
-          when closed.
-        </p>
-
-        <p>
-          The <code>alert--overlay</code> class will overlay the alert at the
-          top of its
-          <code>position: relative</code>
-          container.
-        </p>
-
-        <p>
-          The <code>alert--sm</code> class is intended to be used inside a
-          component, and generally not at a page level.
-        </p>
-
-        <div class="alert" role="alert">
-          <div class="alert__icon">
-            <i
-              class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-question"
-            ></i>
-          </div>
-          <div class="alert__text">Single line message</div>
-        </div>
-
-        <div class="alert alert--info" role="alert">
-          <div class="alert__icon">
-            <i class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-info"></i>
-          </div>
-          <div class="alert__text">Single line informational message</div>
-        </div>
-        <div class="alert alert--sm alert--info" role="alert">
-          <div class="alert__icon">
-            <i class="fa-duotone fa-sharp fa-light fa-circle-info"></i>
-          </div>
-          <div class="alert__text">
-            Small single line informational message using
-            <code>alert--sm</code> modifier
-          </div>
-        </div>
-        <div class="alert alert--success alert--removable" role="alert">
-          <div class="alert__icon">
-            <i class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-check"></i>
-          </div>
-          <div class="alert__text">
-            Single <a href="#">line success</a> message that&rsquo;s a little
-            long
-          </div>
-          <button type="button" class="alert__close" aria-label="Close">
-            <i class="fa-duotone fa-sharp fa-light fa-xl fa-xmark"></i>
-          </button>
-        </div>
-        <div
-          class="alert alert--sm alert--success alert--removable"
-          role="alert"
-        >
-          <div class="alert__icon">
-            <i class="fa-duotone fa-sharp fa-light fa-circle-check"></i>
-          </div>
-          <div class="alert__text">
-            Small single <a href="#">line success</a> message that&rsquo;s a
-            little long
-          </div>
-          <button type="button" class="alert__close" aria-label="Close">
-            <i class="fa-duotone fa-sharp fa-light fa-xmark"></i>
-          </button>
-        </div>
-        <div class="alert alert--warning" role="alert">
-          <div class="alert__icon">
-            <i
-              class="fa-duotone fa-sharp fa-light fa-2xl fa-triangle-exclamation"
-            ></i>
-          </div>
-          <div class="alert__text">Single line warning message</div>
-        </div>
-        <div class="alert alert--danger" role="alert">
-          <div class="alert__icon">
-            <i
-              class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-exclamation"
-            ></i>
-          </div>
-          <div class="alert__text">
-            <p>Multiple line error message that&rsquo;s a little long</p>
-            <p>Multiple line error message</p>
-            <ul>
-              <li>Item to correct</li>
-              <li>Item to correct</li>
-              <li>Item to correct</li>
-            </ul>
-          </div>
-          <button type="button" class="alert__close" aria-label="Close">
-            <i class="fa-duotone fa-sharp fa-light fa-xl fa-xmark"></i>
-          </button>
-        </div>
-      </section>
-
-      <section class="section">
-        <h1>Lists</h1>
-
-        <p>
-          Lists are default-styled, with a little extra margin and line-spacing.
-          The bullets are outside, allowing the text to align with other body
-          text.
-        </p>
-        <p>
-          Classes can be applied at the <code>ol</code> and
-          <code>ul</code> level to specify the type of number or bullet to be
-          applied: <code>list list--alpha</code> (a, b, c),
-          <code>list list--roman</code> (i, ii, iii),
-          <code>list list--circle</code>, <code>list list--disc</code>,
-          <code>list list--square</code>, <code>list list--none</code>.
-        </p>
-
-        <h2>Ordered lists</h2>
-        <h3>List 1</h3>
-        <ol>
-          <li>List item<br />multi-line</li>
-          <li>
-            List item
-            <ol class="list list--roman">
-              <li>Nested ordered item</li>
-              <li>Nested ordered item</li>
-              <li>Nested ordered item</li>
-            </ol>
-          </li>
-          <li>List item</li>
-        </ol>
-
-        <h3>List 2</h3>
-        <ol>
-          <li>List item</li>
-          <li>
-            List item
-            <ul class="list list--square">
-              <li>Nested unordered item</li>
-              <li>Nested unordered item</li>
-              <li>Nested unordered item</li>
-            </ul>
-          </li>
-          <li>List item</li>
-        </ol>
-
-        <h2>Unordered lists</h2>
-        <h3>List 1</h3>
-        <ul>
-          <li>List item<br />multi-line</li>
-          <li>
-            List item
-            <ul>
-              <li>Nested item</li>
-              <li>Nested item</li>
-              <li>Nested item</li>
-            </ul>
-          </li>
-          <li>List item</li>
-        </ul>
-
-        <h3>List 2</h3>
-        <ul>
-          <li>List item</li>
-          <li>
-            List item
-            <ol class="list list--alpha">
-              <li>Nested ordered item</li>
-              <li>Nested ordered item</li>
-              <li>Nested ordered item</li>
-            </ol>
-          </li>
-          <li>List item</li>
-        </ul>
-
-        <h2>Plain lists</h2>
-        <h3>List</h3>
-        <ul class="list list--none">
-          <li>List item</li>
-          <li>
-            List item
-            <ul class="list list--disc">
-              <li>Nested item</li>
-              <li>Nested item</li>
-              <li>Nested item</li>
-            </ul>
-          </li>
-          <li>List item</li>
-        </ul>
-      </section>
-
-      <section class="section">
-        <h1>Cards</h1>
-
-        <p class="mb-4">
-          Already used as an example for Colours, cards have a title and body.
-        </p>
-
-        <div class="flex flex--grid">
-          <div
-            class="card flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Default</h2>
-            </div>
-            <div class="card__body">
-              <p>The default card style.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--primary flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Primary</h2>
-            </div>
-            <div class="card__body">
-              <p>The primary colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--secondary flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Secondary</h2>
-            </div>
-            <div class="card__body">
-              <p>The secondary colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--info flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Information</h2>
-            </div>
-            <div class="card__body">
-              <p>The information colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--success flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Success</h2>
-            </div>
-            <div class="card__body">
-              <p>The success colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--warning flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Warning</h2>
-            </div>
-            <div class="card__body">
-              <p>The warning colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--danger flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <div class="card__title">
-              <h2>Danger</h2>
-            </div>
-            <div class="card__body">
-              <p>The danger colour card.</p>
-            </div>
-          </div>
-        </div>
-
-        <h2>Dark variants</h2>
-
-        <p class="mb-4">
-          As with buttons, cards also come in a <code>-dark</code> variant.
-        </p>
-
-        <div class="flex flex--grid">
-          <div
-            class="card card--primary-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
-          >
-            <div class="card__title">
-              <h2>Primary dark</h2>
-            </div>
-            <div class="card__body">
-              <p>The dark variant of the primary colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--secondary-dark flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Secondary</h2>
-            </div>
-            <div class="card__body">
-              <p>The dark variant of the secondary colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--info-dark flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
-          >
-            <div class="card__title">
-              <h2>Information</h2>
-            </div>
-            <div class="card__body">
-              <p>The dark variant of the information colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--success-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
-          >
-            <div class="card__title">
-              <h2>Success</h2>
-            </div>
-            <div class="card__body">
-              <p>The dark variant of the success colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--warning-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
-          >
-            <div class="card__title">
-              <h2>Warning</h2>
-            </div>
-            <div class="card__body">
-              <p>The dark variant of the warning colour card.</p>
-            </div>
-          </div>
-
-          <div
-            class="card card--danger-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
-          >
-            <div class="card__title">
-              <h2>Danger</h2>
-            </div>
-            <div class="card__body">
-              <p>The dark variant of the danger colour card.</p>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="section">
-        <h1>Images</h1>
-
-        <p>
-          Only a few classes exist to display images, and they&rsquo;re only to
-          apply a little style around images:
-        </p>
-
-        <ul>
-          <li><code>img img--default</code>: padded with rounded border</li>
-          <li><code>img--round</code>: with <code>img</code>, circular</li>
-          <li>
-            <code>img--rounded</code>: with <code>img</code>, rounded corners
-          </li>
-          <li>
-            <code>img--padded</code>: with <code>img</code>, padded, white
-            background
-          </li>
-          <li><code>img--border</code>: with <code>img</code>, grey border</li>
-        </ul>
-
-        <div class="flex flex--grid">
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--default"
-              src="https://placebeard.it/320x240"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--default</code>
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--round"
-              src="https://placebeard.it/640x640"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--round</code>. A circle requires a square image.
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--rounded"
-              src="https://placebeard.it/360x270"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--rounded</code>
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--padded"
-              src="https://placebeard.it/480x360"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--padded</code>
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--round img--padded"
-              src="https://placebeard.it/400x300"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--round img--padded</code>
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--border img--padded"
-              src="https://placebeard.it/640x480"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--border img--padded</code>
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img
-              class="img img--border img--rounded"
-              src="https://placebeard.it/240x180"
-              alt=""
-            />
-            <figcaption class="text-sm text-muted">
-              <code>img img--border img--rounded</code>
-            </figcaption>
-          </figure>
-
-          <figure
-            class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
-          >
-            <img class="img" src="https://placebeard.it/520x390" alt="" />
-            <figcaption class="text-sm text-muted">
-              <code>img</code>
-            </figcaption>
-          </figure>
-        </div>
-
-        <p class="text-sm text-muted">
-          <i class="fa-duotone fa-sharp fa-light fa-asterisk"></i> Images from
-          <a href="https://placebeard.it/">placebeard.it</a>.
-        </p>
-      </section>
-
-      <section class="section">
-        <h1>Badges</h1>
-
-        <h2>Variants</h2>
-
-        <p>
-          <span class="badge">Default</span>
-          <span class="badge badge--primary">Primary</span>
-          <span class="badge badge--secondary">Secondary</span>
-          <span class="badge badge--success">Success</span>
-          <span class="badge badge--danger">Danger</span>
-          <span class="badge badge--warning">Warning</span>
-          <span class="badge badge--info">Info</span>
-          <span class="badge badge--light">Light</span>
-          <span class="badge badge--dark">Dark</span>
-        </p>
-
-        <h2>Pill</h2>
-
-        <p>Add <code>.badge--pill</code> for a rounded pill shape.</p>
-
-        <p>
-          <span class="badge badge--pill">Default</span>
-          <span class="badge badge--pill badge--primary">Primary</span>
-          <span class="badge badge--pill badge--secondary">Secondary</span>
-          <span class="badge badge--pill badge--success">Success</span>
-          <span class="badge badge--pill badge--danger">Danger</span>
-          <span class="badge badge--pill badge--warning">Warning</span>
-          <span class="badge badge--pill badge--info">Info</span>
-          <span class="badge badge--pill badge--light">Light</span>
-          <span class="badge badge--pill badge--dark">Dark</span>
-        </p>
-
-        <h2>In context</h2>
-
-        <p>
-          Badges scale to their parent element's font size and can be placed
-          inline with text.
-        </p>
-
-        <h3>In headings <span class="badge badge--primary">New</span></h3>
-
-        <h4>Subheading <span class="badge badge--secondary">Beta</span></h4>
-
-        <p>
-          Unread messages
-          <span class="badge badge--danger badge--pill">4</span>
-        </p>
-
-        <p>
-          <a href="#" class="button button--primary">
-            Notifications <span class="badge badge--light ms-1">12</span>
-          </a>
-          <a href="#" class="button button--dark">
-            Alerts <span class="badge badge--pill badge--danger ms-1">3</span>
-          </a>
-        </p>
-      </section>
-
-      <section class="section">
-        <h1>Modals</h1>
-
-        <p>
-          Modals use the native <code>&lt;dialog&gt;</code> element with
-          <code>showModal()</code>. Use <code>data-modal-target</code> on a
-          trigger and a matching <code>id</code> on the dialog. A
-          <code>&lt;form method="dialog"&gt;</code> inside the modal closes it
-          natively via any submit button — no extra JavaScript needed.
-        </p>
-
-        <p>
-          <button
-            class="button button--primary"
-            data-modal-target="modal-basic"
-          >
-            Basic modal
-          </button>
-          <button class="button" data-modal-target="modal-sm">
-            Small modal
-          </button>
-          <button class="button" data-modal-target="modal-lg">
-            Large modal
-          </button>
-          <button class="button" data-modal-target="modal-form">
-            Modal with form
-          </button>
-          <button class="button" data-modal-target="modal-centered">
-            Centered modal
-          </button>
-        </p>
-
-        <!-- Basic modal -->
-        <dialog id="modal-basic" class="modal">
-          <form method="dialog">
-            <div class="modal__header">
-              <h2 class="modal__title">Modal title</h2>
-              <button class="modal__close" aria-label="Close">&times;</button>
-            </div>
-            <div class="modal__body">
-              <p>
-                This is a basic modal dialog. It blocks interaction with the
-                rest of the page until dismissed.
-              </p>
-              <p>
-                Click outside the modal or press <kbd>Escape</kbd> to close.
-              </p>
-            </div>
-            <div class="modal__footer">
-              <button type="submit" class="button">Close</button>
-              <button type="submit" class="button button--primary">
-                Save changes
+            <h2>Dark mode</h2>
+
+            <p>
+              A dark mode is available by adding
+              <code>data-mode="dark"</code> to the <code>&lt;html&gt;</code> tag
+              or <code>class="theme--dark"</code> to the
+              <code>&lt;body&gt;</code> tag.
+            </p>
+
+            <p>
+              <button
+                class="button"
+                type="button"
+                data-mode="dark"
+                data-toggle-dark-mode
+              >
+                Toggle <span class="px-1" data-color="light">dark</span
+                ><span class="d-none px-1" data-color="dark">light</span> mode
               </button>
-            </div>
-          </form>
-        </dialog>
+            </p>
 
-        <!-- Small modal -->
-        <dialog id="modal-sm" class="modal modal--sm">
-          <form method="dialog">
-            <div class="modal__header">
-              <h2 class="modal__title">Confirm</h2>
-              <button class="modal__close" aria-label="Close">&times;</button>
-            </div>
-            <div class="modal__body">
-              <p>
-                Are you sure you want to delete this item? This action cannot be
-                undone.
-              </p>
-            </div>
-            <div class="modal__footer">
-              <button type="submit" class="button">Cancel</button>
-              <button type="submit" class="button button--danger">
-                Delete
-              </button>
-            </div>
-          </form>
-        </dialog>
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;button class="button" type="button" data-mode="dark" data-toggle-dark-mode&gt;
+  Toggle dark mode
+&lt;/button&gt;</code></pre>
+              </div>
+            </details>
+          </section>
 
-        <!-- Large modal -->
-        <dialog id="modal-lg" class="modal modal--lg">
-          <form method="dialog">
-            <div class="modal__header">
-              <h2 class="modal__title">Terms and conditions</h2>
-              <button class="modal__close" aria-label="Close">&times;</button>
-            </div>
-            <div class="modal__body">
-              <p>
-                Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do
-                eiusmod tempor incididunt ut labore et dolore magna aliqua.
-              </p>
-              <p>
-                Ut enim ad minim veniam, quis nostrud exercitation ullamco
-                laboris nisi ut aliquip ex ea commodo consequat.
-              </p>
-              <p>
-                Duis aute irure dolor in reprehenderit in voluptate velit esse
-                cillum dolore eu fugiat nulla pariatur.
-              </p>
-              <p>
-                Excepteur sint occaecat cupidatat non proident, sunt in culpa
-                qui officia deserunt mollit anim id est laborum.
-              </p>
-            </div>
-            <div class="modal__footer">
-              <button type="submit" class="button">Decline</button>
-              <button type="submit" class="button button--primary">
-                Accept
-              </button>
-            </div>
-          </form>
-        </dialog>
+          <section id="typography" class="section">
+            <h1>Typography</h1>
 
-        <!-- Modal with form -->
-        <dialog id="modal-form" class="modal">
-          <form method="dialog">
-            <div class="modal__header">
-              <h2 class="modal__title">Edit profile</h2>
-              <button class="modal__close" aria-label="Close">&times;</button>
+            <h2>Headings</h2>
+
+            <h1>Heading 1 <span class="subheading">Sub-heading</span></h1>
+            <h2>Heading 2 <span class="subheading">Sub-heading</span></h2>
+            <h3>Heading 3 <span class="subheading">Sub-heading</span></h3>
+            <h4>Heading 4 <span class="subheading">Sub-heading</span></h4>
+            <h5>Heading 5 <span class="subheading">Sub-heading</span></h5>
+            <h6>Heading 6 <span class="subheading">Sub-heading</span></h6>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;h1&gt;Heading 1 &lt;span class="subheading"&gt;Sub-heading&lt;/span&gt;&lt;/h1&gt;
+&lt;h2&gt;Heading 2 &lt;span class="subheading"&gt;Sub-heading&lt;/span&gt;&lt;/h2&gt;
+&lt;h3&gt;Heading 3&lt;/h3&gt;</code></pre>
+              </div>
+            </details>
+
+            <h2>Paragraphs</h2>
+
+            <p>
+              <span class="lede">Paragraph lorem ipsum dolor sit amet,</span>
+              consectetur adipiscing elit. Nulla tempus massa eu est
+              ullamcorper, luctus pellentesque leo molestie. Etiam ipsum magna,
+              egestas ac massa gravida, condimentum scelerisque leo.
+            </p>
+
+            <p>
+              You can add a <code>&lt;span class="lede"/&gt;</code> for emphasis
+              of the first part of a paragraph.
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;p&gt;
+  &lt;span class="lede"&gt;Lead sentence of the paragraph,&lt;/span&gt;
+  followed by normal body text.
+&lt;/p&gt;</code></pre>
+              </div>
+            </details>
+
+            <p>
+              Maecenas commodo malesuada eros vitae pellentesque. In suscipit
+              finibus molestie. Sed in ultricies dolor. Vivamus quis varius
+              nisl, at fringilla felis. Sed faucibus ullamcorper arcu in
+              commodo. Cras euismod lacus id volutpat porta. Etiam vel posuere
+              enim, eu accumsan sem. Mauris ante purus, mattis quis ante vel,
+              iaculis mattis nulla. Donec finibus sem nec dictum vestibulum. Sed
+              vitae augue quis ligula efficitur fermentum non eu nulla. Proin
+              tincidunt ullamcorper blandit.
+            </p>
+            <p>
+              Pellentesque efficitur et orci nec lacinia. Integer congue justo
+              in libero eleifend ullamcorper. Nullam rutrum, lorem eget
+              efficitur placerat, turpis libero faucibus est, at aliquam arcu
+              justo sit amet nibh. Sed mollis enim tristique tortor pulvinar
+              bibendum. Nullam vel maximus dolor, at ornare velit. Nunc
+              efficitur elit at felis pulvinar, vel fermentum justo gravida.
+              Proin volutpat quam neque, in porta elit cursus at. Nam id velit
+              semper, finibus sem id, fermentum sapien. Aliquam lobortis nisl a
+              libero fringilla sollicitudin.
+            </p>
+
+            <h2>Links</h2>
+
+            <h2><a href="#">Heading 2 link</a></h2>
+            <h3><a href="#">Heading 3 link</a></h3>
+
+            <p>
+              Lorem ipsum dolor <a href="#">sit amet,</a> consectetur adipiscing
+              elit.
+            </p>
+            <p>
+              Nulla tempus <a href="#">massa eu est</a> ullamcorper, luctus
+              pellentesque leo molestie.
+            </p>
+            <p>
+              Etiam ipsum magna,
+              <a href="#">egestas ac massa gravida,</a> condimentum scelerisque
+              leo.
+            </p>
+
+            <p>
+              Remove <code>:hover</code>, <code>:active</code> and
+              <code>:visited</code> styles by adding the
+              <code>permanent</code> class.
+            </p>
+
+            <p>
+              Lorem ipsum dolor
+              <a href="#" class="permanent">sit amet,</a> consectetur adipiscing
+              elit.
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;a href="#" class="permanent"&gt;Link without hover/active/visited styles&lt;/a&gt;</code></pre>
+              </div>
+            </details>
+
+            <h2>Text variants</h2>
+
+            <p class="text-primary">
+              Primary lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+
+            <p class="text-secondary">
+              Secondary lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+
+            <p class="text-info">
+              Information lorem ipsum dolor sit amet, consectetur adipiscing
+              elit.
+            </p>
+
+            <p class="text-success">
+              Success lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+
+            <p class="text-warning">
+              Warning lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+
+            <p class="text-danger">
+              Danger lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+
+            <p class="text-muted">
+              Muted lorem ipsum dolor sit amet, consectetur adipiscing elit.
+            </p>
+          </section>
+
+          <section id="tables" class="section">
+            <h1>Tables</h1>
+
+            <h2>Base</h2>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;table class="table"&gt;
+  &lt;caption&gt;Table caption&lt;/caption&gt;
+  &lt;thead&gt;
+    &lt;tr&gt;
+      &lt;th&gt;Name&lt;/th&gt;
+      &lt;th&gt;Role&lt;/th&gt;
+    &lt;/tr&gt;
+  &lt;/thead&gt;
+  &lt;tbody&gt;
+    &lt;tr&gt;
+      &lt;td&gt;Alice Smith&lt;/td&gt;
+      &lt;td&gt;Developer&lt;/td&gt;
+    &lt;/tr&gt;
+  &lt;/tbody&gt;
+  &lt;tfoot&gt;
+    &lt;tr&gt;&lt;td colspan="2"&gt;1 member&lt;/td&gt;&lt;/tr&gt;
+  &lt;/tfoot&gt;
+&lt;/table&gt;
+
+&lt;!-- Modifiers (combinable): table--striped  table--bordered  table--hover  table--sm --&gt;
+&lt;table class="table table--striped"&gt;...&lt;/table&gt;</code></pre>
+              </div>
+            </details>
+
+            <table class="table">
+              <caption>
+                Table caption
+              </caption>
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Department</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Alice Smith</td>
+                  <td>Engineering</td>
+                  <td>Developer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Bob Jones</td>
+                  <td>Design</td>
+                  <td>Designer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Carol White</td>
+                  <td>Marketing</td>
+                  <td>Manager</td>
+                  <td>On leave</td>
+                </tr>
+                <tr>
+                  <td>David Brown</td>
+                  <td>Finance</td>
+                  <td>Analyst</td>
+                  <td>Active</td>
+                </tr>
+              </tbody>
+              <tfoot>
+                <tr>
+                  <td colspan="4">4 team members</td>
+                </tr>
+              </tfoot>
+            </table>
+
+            <h2>Striped</h2>
+
+            <table class="table table--striped">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Department</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Alice Smith</td>
+                  <td>Engineering</td>
+                  <td>Developer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Bob Jones</td>
+                  <td>Design</td>
+                  <td>Designer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Carol White</td>
+                  <td>Marketing</td>
+                  <td>Manager</td>
+                  <td>On leave</td>
+                </tr>
+                <tr>
+                  <td>David Brown</td>
+                  <td>Finance</td>
+                  <td>Analyst</td>
+                  <td>Active</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Bordered</h2>
+
+            <table class="table table--bordered">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Department</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Alice Smith</td>
+                  <td>Engineering</td>
+                  <td>Developer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Bob Jones</td>
+                  <td>Design</td>
+                  <td>Designer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Carol White</td>
+                  <td>Marketing</td>
+                  <td>Manager</td>
+                  <td>On leave</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Hover</h2>
+
+            <table class="table table--hover">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Department</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Alice Smith</td>
+                  <td>Engineering</td>
+                  <td>Developer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Bob Jones</td>
+                  <td>Design</td>
+                  <td>Designer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Carol White</td>
+                  <td>Marketing</td>
+                  <td>Manager</td>
+                  <td>On leave</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Small</h2>
+
+            <table class="table table--sm">
+              <thead>
+                <tr>
+                  <th>Name</th>
+                  <th>Department</th>
+                  <th>Role</th>
+                  <th>Status</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Alice Smith</td>
+                  <td>Engineering</td>
+                  <td>Developer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Bob Jones</td>
+                  <td>Design</td>
+                  <td>Designer</td>
+                  <td>Active</td>
+                </tr>
+                <tr>
+                  <td>Carol White</td>
+                  <td>Marketing</td>
+                  <td>Manager</td>
+                  <td>On leave</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h2>Responsive</h2>
+
+            <p>
+              Wrap in <code>.table-responsive</code> to enable horizontal scroll
+              on narrow viewports.
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="table-responsive"&gt;
+  &lt;table class="table table--bordered"&gt;
+    &lt;thead&gt;...&lt;/thead&gt;
+    &lt;tbody&gt;...&lt;/tbody&gt;
+  &lt;/table&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+
+            <div class="table-responsive">
+              <table class="table table--bordered">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Email</th>
+                    <th>Department</th>
+                    <th>Role</th>
+                    <th>Location</th>
+                    <th>Start date</th>
+                    <th>Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Alice Smith</td>
+                    <td>alice@example.com</td>
+                    <td>Engineering</td>
+                    <td>Developer</td>
+                    <td>Toronto</td>
+                    <td>2021-03-15</td>
+                    <td>Active</td>
+                  </tr>
+                  <tr>
+                    <td>Bob Jones</td>
+                    <td>bob@example.com</td>
+                    <td>Design</td>
+                    <td>Designer</td>
+                    <td>Vancouver</td>
+                    <td>2019-11-01</td>
+                    <td>Active</td>
+                  </tr>
+                  <tr>
+                    <td>Carol White</td>
+                    <td>carol@example.com</td>
+                    <td>Marketing</td>
+                    <td>Manager</td>
+                    <td>Montreal</td>
+                    <td>2018-06-20</td>
+                    <td>On leave</td>
+                  </tr>
+                </tbody>
+              </table>
             </div>
-            <div class="modal__body">
+          </section>
+
+          <section id="forms" class="section">
+            <h1>Forms</h1>
+
+            <form class="form">
               <div class="form__group">
-                <label class="form__label" for="modal-name">Name</label>
+                <label class="form__label form__label--lg"
+                  >Input large label</label
+                >
+                <input class="form__control form__control--lg" type="text" />
+                <p class="text-muted text-sm">Some help text for this input.</p>
+              </div>
+
+              <div class="form__group">
+                <label class="form__label">Input label</label>
+                <input class="form__control" type="text" required />
+              </div>
+
+              <div class="form__group">
+                <label class="form__label form__label--sm"
+                  >Input label small</label
+                >
                 <input
-                  id="modal-name"
-                  class="form__control"
+                  class="form__control form__control--sm"
                   type="text"
-                  placeholder="Your name"
+                  required
                 />
               </div>
+
               <div class="form__group">
-                <label class="form__label" for="modal-email">Email</label>
-                <input
-                  id="modal-email"
+                <label class="form__label">Select label</label>
+                <select
+                  id="select-control"
+                  name="select_control"
                   class="form__control"
-                  type="email"
-                  placeholder="your@email.com"
-                />
-              </div>
-              <div class="form__group">
-                <label class="form__label" for="modal-role">Role</label>
-                <select id="modal-role" class="form__control">
-                  <option value="">Select a role</option>
-                  <option value="admin">Admin</option>
-                  <option value="editor">Editor</option>
-                  <option value="viewer">Viewer</option>
+                  required
+                >
+                  <option value="">Select</option>
+                  <option value="1">Option 1</option>
+                  <option value="2">Option 2</option>
                 </select>
               </div>
-            </div>
-            <div class="modal__footer">
-              <button type="submit" class="button">Cancel</button>
-              <button type="submit" class="button button--primary">Save</button>
-            </div>
-          </form>
-        </dialog>
 
-        <!-- Centered modal -->
-        <dialog id="modal-centered" class="modal modal--centered">
-          <form method="dialog">
-            <div class="modal__header">
-              <h2 class="modal__title">Centered modal</h2>
-              <button class="modal__close" aria-label="Close">&times;</button>
-            </div>
-            <div class="modal__body">
-              <p>
-                This modal uses <code>.modal--centered</code> to restore the
-                browser's default vertical centering.
-              </p>
-            </div>
-            <div class="modal__footer">
-              <button type="submit" class="button button--primary">
-                Got it
-              </button>
-            </div>
-          </form>
-        </dialog>
-      </section>
+              <fieldset class="form__group">
+                <legend class="form__label">Checkbox group</legend>
+                <div id="checkbox-error"></div>
+                <div class="form__check">
+                  <label
+                    ><input
+                      type="checkbox"
+                      name="checkbox[]"
+                      required
+                      data-bouncer-target="#checkbox-error"
+                    />
+                    Checkbox input</label
+                  >
+                </div>
+                <div class="form__check">
+                  <label
+                    ><input
+                      type="checkbox"
+                      name="checkbox[]"
+                      required
+                      data-bouncer-target="#checkbox-error"
+                    />
+                    Checkbox input</label
+                  >
+                </div>
+              </fieldset>
 
-      <section class="section">
-        <h1>Accordion / Disclosure</h1>
+              <fieldset class="form__group">
+                <legend class="form__label">Radio group</legend>
+                <div id="radio-error"></div>
+                <div class="form__check">
+                  <label
+                    ><input
+                      type="radio"
+                      name="radio"
+                      required
+                      data-bouncer-target="#radio-error"
+                    />
+                    Radio input</label
+                  >
+                </div>
+                <div class="form__check">
+                  <label
+                    ><input
+                      type="radio"
+                      name="radio"
+                      required
+                      data-bouncer-target="#radio-error"
+                    />
+                    Radio input</label
+                  >
+                </div>
+              </fieldset>
 
-        <p>
-          Built on the native <code>&lt;details&gt;</code> and
-          <code>&lt;summary&gt;</code> elements — no JavaScript required for
-          basic expand/collapse behaviour.
-        </p>
+              <div class="form__group">
+                <label class="form__label">Input label</label>
+                <input
+                  class="form__control form__control--file"
+                  type="file"
+                  required
+                />
+              </div>
 
-        <h2>Standalone disclosure</h2>
+              <div class="form__group">
+                <button class="button">Submit</button>
+              </div>
+            </form>
 
-        <details class="disclosure">
-          <summary class="disclosure__trigger">What is Albert CSS?</summary>
-          <div class="disclosure__body">
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;form class="form"&gt;
+  &lt;!-- Sizes: form__label--lg/sm + form__control--lg/sm --&gt;
+  &lt;div class="form__group"&gt;
+    &lt;label class="form__label" for="name"&gt;Label&lt;/label&gt;
+    &lt;input id="name" class="form__control" type="text" required /&gt;
+    &lt;p class="text-muted text-sm"&gt;Optional help text.&lt;/p&gt;
+  &lt;/div&gt;
+
+  &lt;div class="form__group"&gt;
+    &lt;label class="form__label" for="role"&gt;Select label&lt;/label&gt;
+    &lt;select id="role" class="form__control" required&gt;
+      &lt;option value=""&gt;Select&lt;/option&gt;
+      &lt;option value="1"&gt;Option 1&lt;/option&gt;
+    &lt;/select&gt;
+  &lt;/div&gt;
+
+  &lt;fieldset class="form__group"&gt;
+    &lt;legend class="form__label"&gt;Checkbox group&lt;/legend&gt;
+    &lt;div id="check-error"&gt;&lt;/div&gt;
+    &lt;div class="form__check"&gt;
+      &lt;label&gt;
+        &lt;input type="checkbox" name="opts[]" required data-bouncer-target="#check-error" /&gt;
+        Option A
+      &lt;/label&gt;
+    &lt;/div&gt;
+  &lt;/fieldset&gt;
+
+  &lt;fieldset class="form__group"&gt;
+    &lt;legend class="form__label"&gt;Radio group&lt;/legend&gt;
+    &lt;div id="radio-error"&gt;&lt;/div&gt;
+    &lt;div class="form__check"&gt;
+      &lt;label&gt;
+        &lt;input type="radio" name="choice" required data-bouncer-target="#radio-error" /&gt;
+        Choice A
+      &lt;/label&gt;
+    &lt;/div&gt;
+  &lt;/fieldset&gt;
+
+  &lt;div class="form__group"&gt;
+    &lt;button class="button" type="submit"&gt;Submit&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/form&gt;</code></pre>
+              </div>
+            </details>
+
+            <h2>Inline</h2>
+
             <p>
-              Albert CSS is a personal CSS framework based on Bootstrap v4,
-              built with vanilla JS and no framework dependencies.
+              <code>.form--inline</code> class can be used to display form
+              controls inline. On smaller screens, the controls will wrap to the
+              next line.
             </p>
-          </div>
-        </details>
 
-        <details class="disclosure">
-          <summary class="disclosure__trigger">How do I use it?</summary>
-          <div class="disclosure__body">
+            <form class="form form--inline">
+              <div class="form__group">
+                <label class="form__label">Input label</label>
+                <input class="form__control" type="text" />
+              </div>
+
+              <div class="form__group">
+                <label class="form__label visually-hidden">Select label</label>
+                <select
+                  id="select-control-2"
+                  name="select_control_2"
+                  class="form__control"
+                >
+                  <option value="">Select</option>
+                  <option value="1">Option 1</option>
+                  <option value="2">Option 2</option>
+                </select>
+              </div>
+
+              <div class="form__group">
+                <button class="button">Submit</button>
+              </div>
+            </form>
+
+            <form class="form form--inline">
+              <div class="form__group">
+                <label class="form__label">Input label</label>
+                <input class="form__control form__control--lg" type="text" />
+              </div>
+
+              <div class="form__group">
+                <label class="form__label visually-hidden">Select label</label>
+                <select
+                  id="select-control-2"
+                  name="select_control_2"
+                  class="form__control form__control--lg"
+                >
+                  <option value="">Select</option>
+                  <option value="1">Option 1</option>
+                  <option value="2">Option 2</option>
+                </select>
+              </div>
+
+              <div class="form__group">
+                <button class="button button--lg">Submit</button>
+              </div>
+            </form>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;form class="form form--inline"&gt;
+  &lt;div class="form__group"&gt;
+    &lt;label class="form__label"&gt;Search&lt;/label&gt;
+    &lt;input class="form__control" type="text" /&gt;
+  &lt;/div&gt;
+  &lt;div class="form__group"&gt;
+    &lt;button class="button button--primary" type="submit"&gt;Search&lt;/button&gt;
+  &lt;/div&gt;
+&lt;/form&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="buttons" class="section">
+            <h1>Buttons</h1>
+
             <p>
-              Include the compiled CSS and JS files in your HTML. Use the
-              provided class names to style your components.
+              Button classes can be applied to <code>&lt;a&gt;</code>,
+              <code>&lt;button&gt;</code> or
+              <code>&lt;input type="button|submit|reset"&gt;</code> tags.
             </p>
-          </div>
-        </details>
 
-        <details class="disclosure" open>
-          <summary class="disclosure__trigger">This one starts open</summary>
-          <div class="disclosure__body">
             <p>
-              Add the <code>open</code> attribute to a
-              <code>&lt;details&gt;</code> element to have it expanded on load.
+              <button class="button">Default</button>
+              <button class="button button--primary">Primary</button>
+              <button class="button button--secondary">Secondary</button>
+              <button class="button button--info">Info</button>
+              <button class="button button--success">Success</button>
+              <button class="button button--warning">Warning</button>
+              <button class="button button--danger">Danger</button>
+              <a href="#" class="button button--link">Link</a>
             </p>
-          </div>
-        </details>
 
-        <h2>Accordion</h2>
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;button class="button" type="button"&gt;Default&lt;/button&gt;
+&lt;button class="button button--primary" type="button"&gt;Primary&lt;/button&gt;
+&lt;button class="button button--secondary" type="button"&gt;Secondary&lt;/button&gt;
+&lt;button class="button button--info" type="button"&gt;Info&lt;/button&gt;
+&lt;button class="button button--success" type="button"&gt;Success&lt;/button&gt;
+&lt;button class="button button--warning" type="button"&gt;Warning&lt;/button&gt;
+&lt;button class="button button--danger" type="button"&gt;Danger&lt;/button&gt;
+&lt;a href="#" class="button button--link"&gt;Link&lt;/a&gt;</code></pre>
+              </div>
+            </details>
 
-        <p>
-          Wrap multiple items in <code>.accordion</code> to connect them
-          visually. Each <code>.accordion__item</code> closes its siblings when
-          opened.
-        </p>
+            <p>Buttons also come in a <code>-dark</code> variant.</p>
 
-        <div class="accordion">
-          <details class="accordion__item">
-            <summary class="accordion__trigger">
-              Getting started
-              <i
-                class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
-                aria-hidden="true"
-              ></i>
-            </summary>
-            <div class="accordion__body">
-              <p>
-                Download or link to the CSS and JS files. No build tools
-                required for basic usage.
-              </p>
-            </div>
-          </details>
-          <details class="accordion__item">
-            <summary class="accordion__trigger">
-              Customisation
-              <i
-                class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
-                aria-hidden="true"
-              ></i>
-            </summary>
-            <div class="accordion__body">
-              <p>
-                Override CSS custom properties in your own stylesheet to change
-                colours, spacing, and typography without touching the source.
-              </p>
-            </div>
-          </details>
-          <details class="accordion__item">
-            <summary class="accordion__trigger">
-              Browser support
-              <i
-                class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
-                aria-hidden="true"
-              ></i>
-            </summary>
-            <div class="accordion__body">
-              <p>
-                All modern browsers. The <code>&lt;details&gt;</code> element is
-                supported in every evergreen browser and has been since 2020.
-              </p>
-            </div>
-          </details>
-          <details class="accordion__item">
-            <summary class="accordion__trigger">
-              Accessibility
-              <i
-                class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
-                aria-hidden="true"
-              ></i>
-            </summary>
-            <div class="accordion__body">
-              <p>
-                <code>&lt;details&gt;</code> and
-                <code>&lt;summary&gt;</code> are natively keyboard accessible
-                and exposed correctly to assistive technology — no ARIA
-                attributes required.
-              </p>
-            </div>
-          </details>
-        </div>
-
-        <p class="m-t-md">
-          Add custom details marker icons by including an element with the
-          <code>disclosure__icon</code> or <code>accordion__icon</code> class
-          inside the <code>summary</code> element.
-        </p>
-      </section>
-
-      <section class="section">
-        <h1>Tabs</h1>
-
-        <p>
-          Use <code>role="tablist"</code>, <code>role="tab"</code>, and
-          <code>role="tabpanel"</code> with matching
-          <code>aria-controls</code> / <code>id</code> pairs. The active tab is
-          indicated by <code>aria-selected="true"</code>; inactive panels use
-          the <code>hidden</code> attribute. Arrow keys, <kbd>Home</kbd>, and
-          <kbd>End</kbd> navigate between tabs.
-        </p>
-
-        <div class="tabs">
-          <div class="tabs__list" role="tablist" aria-label="Example tabs">
-            <button
-              class="tabs__tab"
-              role="tab"
-              id="tab-overview"
-              aria-controls="panel-overview"
-              aria-selected="true"
-              tabindex="0"
-            >
-              Overview
-            </button>
-            <button
-              class="tabs__tab"
-              role="tab"
-              id="tab-usage"
-              aria-controls="panel-usage"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              Usage
-            </button>
-            <button
-              class="tabs__tab"
-              role="tab"
-              id="tab-accessibility"
-              aria-controls="panel-accessibility"
-              aria-selected="false"
-              tabindex="-1"
-            >
-              Accessibility
-            </button>
-          </div>
-
-          <div
-            class="tabs__panel"
-            role="tabpanel"
-            id="panel-overview"
-            aria-labelledby="tab-overview"
-          >
             <p>
-              Tabs organize content into separate views where only one is
-              visible at a time. Use them when content can be meaningfully
-              grouped into distinct, parallel sections.
+              <button class="button button--dark">Default</button>
+              <button class="button button--primary-dark">Primary</button>
+              <button class="button button--secondary-dark">Secondary</button>
+              <button class="button button--info-dark">Info</button>
+              <button class="button button--success-dark">Success</button>
+              <button class="button button--warning-dark">Warning</button>
+              <button class="button button--danger-dark">Danger</button>
             </p>
-          </div>
 
-          <div
-            class="tabs__panel"
-            role="tabpanel"
-            id="panel-usage"
-            aria-labelledby="tab-usage"
-            hidden
-          >
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;button class="button button--dark" type="button"&gt;Default&lt;/button&gt;
+&lt;button class="button button--primary-dark" type="button"&gt;Primary&lt;/button&gt;
+&lt;button class="button button--secondary-dark" type="button"&gt;Secondary&lt;/button&gt;
+&lt;button class="button button--info-dark" type="button"&gt;Info&lt;/button&gt;
+&lt;button class="button button--success-dark" type="button"&gt;Success&lt;/button&gt;
+&lt;button class="button button--warning-dark" type="button"&gt;Warning&lt;/button&gt;
+&lt;button class="button button--danger-dark" type="button"&gt;Danger&lt;/button&gt;</code></pre>
+              </div>
+            </details>
+
             <p>
-              Add <code>aria-selected="true"</code> and
-              <code>tabindex="0"</code> to the initially active tab. All other
-              tabs get <code>aria-selected="false"</code> and
-              <code>tabindex="-1"</code>. Match each tab's
-              <code>aria-controls</code> to its panel's <code>id</code>.
+              Buttons also come in three sizes: default,
+              <code>button--sm</code> and <code>button--lg</code>.
             </p>
-          </div>
 
-          <div
-            class="tabs__panel"
-            role="tabpanel"
-            id="panel-accessibility"
-            aria-labelledby="tab-accessibility"
-            hidden
-          >
+            <p><button class="button button--lg">Large</button></p>
+            <p><button class="button button--primary">Default</button></p>
             <p>
-              The tab list follows the ARIA authoring practices roving-tabindex
-              pattern. Only the active tab is in the tab sequence; arrow keys
-              move focus between tabs and activate the focused tab.
+              <button class="button button--secondary button--sm">Small</button>
             </p>
-          </div>
-        </div>
-      </section>
 
-      <section class="section">
-        <h1>Dropdowns</h1>
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;button class="button button--primary button--lg" type="button"&gt;Large&lt;/button&gt;
+&lt;button class="button button--primary" type="button"&gt;Default&lt;/button&gt;
+&lt;button class="button button--primary button--sm" type="button"&gt;Small&lt;/button&gt;</code></pre>
+              </div>
+            </details>
 
-        <p>
-          A <code>.dropdown__trigger</code> button toggles a
-          <code>.dropdown__menu</code>. Arrow keys navigate items;
-          <kbd>Escape</kbd>
-          closes the menu and returns focus to the trigger.
-        </p>
+            <h2>Button groups</h2>
 
-        <h2>Basic dropdown</h2>
+            <p>
+              Wrap <code>.button</code> elements in a
+              <code>.button-group</code> to connect them into a single control.
+              Buttons share borders and the group has a continuous border-radius
+              on its outer edges.
+            </p>
 
-        <div class="dropdown">
-          <button
-            class="button dropdown__trigger"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-controls="dropdown-basic"
-          >
-            Options
-            <i
-              class="dropdown__icon fa-duotone fa-sharp fa-light fa-chevron-down"
-              aria-hidden="true"
-            ></i>
-          </button>
-          <ul class="dropdown__menu" id="dropdown-basic" role="menu" hidden>
-            <li class="dropdown__item" role="none">
-              <a class="dropdown__link" href="#" role="menuitem">Profile</a>
-            </li>
-            <li class="dropdown__item" role="none">
-              <a class="dropdown__link" href="#" role="menuitem">Settings</a>
-            </li>
-            <li class="dropdown__item" role="none">
-              <button class="dropdown__button" role="menuitem" disabled>
-                Disabled action
-              </button>
-            </li>
-            <li class="dropdown__divider" role="separator"></li>
-            <li class="dropdown__item" role="none">
-              <button
-                class="dropdown__button dropdown__button--danger"
-                role="menuitem"
+            <div>
+              <div
+                class="button-group"
+                role="group"
+                aria-label="Text formatting"
               >
-                Delete account
-              </button>
-            </li>
-          </ul>
-        </div>
+                <button class="button">Default</button>
+                <button class="button">Middle</button>
+                <button class="button">Right</button>
+              </div>
+            </div>
 
-        <div class="dropdown">
-          <button
-            class="button dropdown__trigger"
-            aria-haspopup="true"
-            aria-expanded="false"
-            aria-controls="dropdown-basic"
-          >
-            Options
-          </button>
-          <ul class="dropdown__menu" id="dropdown-basic" role="menu" hidden>
-            <li class="dropdown__item" role="none">
-              <a class="dropdown__link" href="#" role="menuitem">Profile</a>
-            </li>
-            <li class="dropdown__item" role="none">
-              <a class="dropdown__link" href="#" role="menuitem">Settings</a>
-            </li>
-            <li class="dropdown__item" role="none">
-              <button class="dropdown__button" role="menuitem" disabled>
-                Disabled action
-              </button>
-            </li>
-            <li class="dropdown__divider" role="separator"></li>
-            <li class="dropdown__item" role="none">
-              <button
-                class="dropdown__button dropdown__button--danger"
-                role="menuitem"
+            <div>
+              <div
+                class="button-group"
+                role="group"
+                aria-label="Primary actions"
               >
-                Delete account
+                <button class="button button--primary">Left</button>
+                <button class="button button--primary">Middle</button>
+                <button class="button button--primary">Right</button>
+              </div>
+            </div>
+
+            <p>Mixed variants work too:</p>
+
+            <div>
+              <div class="button-group" role="group" aria-label="Mixed">
+                <button class="button button--success">Save</button>
+                <button class="button button--warning">Draft</button>
+                <button class="button button--danger">Delete</button>
+              </div>
+            </div>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="button-group" role="group" aria-label="Actions"&gt;
+  &lt;button class="button" type="button"&gt;Left&lt;/button&gt;
+  &lt;button class="button" type="button"&gt;Middle&lt;/button&gt;
+  &lt;button class="button" type="button"&gt;Right&lt;/button&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+
+            <h3>Radio button group</h3>
+
+            <p>
+              Place a <code>.button-group__input</code> input immediately before
+              its label. The input is visually hidden; the checked state fills
+              the label with the variant colour.
+            </p>
+
+            <div class="button-group" role="group" aria-label="Text alignment">
+              <input
+                class="button-group__input"
+                type="radio"
+                id="align-start"
+                name="align"
+                checked
+              />
+              <label class="button button--primary" for="align-start"
+                >Left</label
+              >
+              <input
+                class="button-group__input"
+                type="radio"
+                id="align-center"
+                name="align"
+              />
+              <label class="button button--primary" for="align-center"
+                >Centre</label
+              >
+              <input
+                class="button-group__input"
+                type="radio"
+                id="align-end"
+                name="align"
+              />
+              <label class="button button--primary" for="align-end"
+                >Right</label
+              >
+            </div>
+
+            <h3>Checkbox button group</h3>
+
+            <p>
+              Same pattern with <code>type="checkbox"</code> for multi-select:
+            </p>
+
+            <div class="button-group" role="group" aria-label="Text style">
+              <input
+                class="button-group__input"
+                type="checkbox"
+                id="style-bold"
+                name="style-bold"
+              />
+              <label class="button button--secondary" for="style-bold"
+                >Bold</label
+              >
+              <input
+                class="button-group__input"
+                type="checkbox"
+                id="style-italic"
+                name="style-italic"
+                checked
+              />
+              <label class="button button--secondary" for="style-italic"
+                >Italic</label
+              >
+              <input
+                class="button-group__input"
+                type="checkbox"
+                id="style-underline"
+                name="style-underline"
+              />
+              <label class="button button--secondary" for="style-underline"
+                >Underline</label
+              >
+            </div>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — radio button group
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="button-group" role="group" aria-label="Alignment"&gt;
+  &lt;input class="button-group__input" type="radio" id="align-l" name="align" checked /&gt;
+  &lt;label class="button button--primary" for="align-l"&gt;Left&lt;/label&gt;
+  &lt;input class="button-group__input" type="radio" id="align-c" name="align" /&gt;
+  &lt;label class="button button--primary" for="align-c"&gt;Centre&lt;/label&gt;
+  &lt;input class="button-group__input" type="radio" id="align-r" name="align" /&gt;
+  &lt;label class="button button--primary" for="align-r"&gt;Right&lt;/label&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — checkbox button group
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="button-group" role="group" aria-label="Style"&gt;
+  &lt;input class="button-group__input" type="checkbox" id="bold" name="bold" /&gt;
+  &lt;label class="button button--secondary" for="bold"&gt;Bold&lt;/label&gt;
+  &lt;input class="button-group__input" type="checkbox" id="italic" name="italic" checked /&gt;
+  &lt;label class="button button--secondary" for="italic"&gt;Italic&lt;/label&gt;
+  &lt;input class="button-group__input" type="checkbox" id="underline" name="underline" /&gt;
+  &lt;label class="button button--secondary" for="underline"&gt;Underline&lt;/label&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="alerts" class="section">
+            <h1>Alerts</h1>
+
+            <p>
+              Alerts come in a few flavours: default, information (info),
+              success, warning and error. Links within the message will inherit
+              the alert text colour, losing the hover, active and visited
+              states.
+            </p>
+
+            <p>Alerts with an <code>alert__close</code> button:</p>
+            <blockquote>
+              <pre><code>&lt;button type="button" class="alert__close" aria-label="Close"&gt;&lt;span class="fa-light fa-xl fa-xmark"&gt;&lt;/i&gt;&lt;/button&gt;</code></pre>
+            </blockquote>
+
+            <p>
+              will be hidden (<code>display: none;</code>) when closed. Alerts
+              with the <code>alert--removable</code> class will be removed from
+              the DOM when closed.
+            </p>
+
+            <p>
+              The <code>alert--overlay</code> class will overlay the alert at
+              the top of its
+              <code>position: relative</code>
+              container.
+            </p>
+
+            <p>
+              The <code>alert--sm</code> class is intended to be used inside a
+              component, and generally not at a page level.
+            </p>
+
+            <div class="alert" role="alert">
+              <div class="alert__icon">
+                <i
+                  class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-question"
+                ></i>
+              </div>
+              <div class="alert__text">Single line message</div>
+            </div>
+
+            <div class="alert alert--info" role="alert">
+              <div class="alert__icon">
+                <i
+                  class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-info"
+                ></i>
+              </div>
+              <div class="alert__text">Single line informational message</div>
+            </div>
+            <div class="alert alert--sm alert--info" role="alert">
+              <div class="alert__icon">
+                <i class="fa-duotone fa-sharp fa-light fa-circle-info"></i>
+              </div>
+              <div class="alert__text">
+                Small single line informational message using
+                <code>alert--sm</code> modifier
+              </div>
+            </div>
+            <div class="alert alert--success alert--removable" role="alert">
+              <div class="alert__icon">
+                <i
+                  class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-check"
+                ></i>
+              </div>
+              <div class="alert__text">
+                Single <a href="#">line success</a> message that&rsquo;s a
+                little long
+              </div>
+              <button type="button" class="alert__close" aria-label="Close">
+                <i class="fa-duotone fa-sharp fa-light fa-xl fa-xmark"></i>
               </button>
-            </li>
-          </ul>
-        </div>
-
-        <h2>Right-aligned dropdown</h2>
-
-        <p>
-          Add <code>.dropdown--right</code> to align the menu to the right edge
-          of the trigger.
-        </p>
-
-        <div class="text-end">
-          <div class="dropdown dropdown--right">
-            <button
-              class="button dropdown__trigger"
-              aria-haspopup="true"
-              aria-expanded="false"
-              aria-controls="dropdown-right"
+            </div>
+            <div
+              class="alert alert--sm alert--success alert--removable"
+              role="alert"
             >
-              Account
-              <i
-                class="dropdown__icon fa-duotone fa-sharp fa-light fa-chevron-down"
-                aria-hidden="true"
-              ></i>
-            </button>
-            <ul class="dropdown__menu" id="dropdown-right" role="menu" hidden>
-              <li class="dropdown__item" role="none">
-                <a class="dropdown__link" href="#" role="menuitem">Profile</a>
+              <div class="alert__icon">
+                <i class="fa-duotone fa-sharp fa-light fa-circle-check"></i>
+              </div>
+              <div class="alert__text">
+                Small single <a href="#">line success</a> message that&rsquo;s a
+                little long
+              </div>
+              <button type="button" class="alert__close" aria-label="Close">
+                <i class="fa-duotone fa-sharp fa-light fa-xmark"></i>
+              </button>
+            </div>
+            <div class="alert alert--warning" role="alert">
+              <div class="alert__icon">
+                <i
+                  class="fa-duotone fa-sharp fa-light fa-2xl fa-triangle-exclamation"
+                ></i>
+              </div>
+              <div class="alert__text">Single line warning message</div>
+            </div>
+            <div class="alert alert--danger" role="alert">
+              <div class="alert__icon">
+                <i
+                  class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-exclamation"
+                ></i>
+              </div>
+              <div class="alert__text">
+                <p>Multiple line error message that&rsquo;s a little long</p>
+                <p>Multiple line error message</p>
+                <ul>
+                  <li>Item to correct</li>
+                  <li>Item to correct</li>
+                  <li>Item to correct</li>
+                </ul>
+              </div>
+              <button type="button" class="alert__close" aria-label="Close">
+                <i class="fa-duotone fa-sharp fa-light fa-xl fa-xmark"></i>
+              </button>
+            </div>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — basic variants
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="alert" role="alert"&gt;
+  &lt;div class="alert__icon"&gt;
+    &lt;i class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-question"&gt;&lt;/i&gt;
+  &lt;/div&gt;
+  &lt;div class="alert__text"&gt;Default message&lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Variants: alert--info  alert--success  alert--warning  alert--danger --&gt;
+&lt;div class="alert alert--info" role="alert"&gt;
+  &lt;div class="alert__icon"&gt;
+    &lt;i class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-info"&gt;&lt;/i&gt;
+  &lt;/div&gt;
+  &lt;div class="alert__text"&gt;Informational message&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — dismissible alert
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;!-- alert--removable removes from DOM on close; without it the alert is hidden only --&gt;
+&lt;div class="alert alert--success alert--removable" role="alert"&gt;
+  &lt;div class="alert__icon"&gt;
+    &lt;i class="fa-duotone fa-sharp fa-light fa-2xl fa-circle-check"&gt;&lt;/i&gt;
+  &lt;/div&gt;
+  &lt;div class="alert__text"&gt;Success message&lt;/div&gt;
+  &lt;button type="button" class="alert__close" aria-label="Close"&gt;
+    &lt;i class="fa-duotone fa-sharp fa-light fa-xl fa-xmark"&gt;&lt;/i&gt;
+  &lt;/button&gt;
+&lt;/div&gt;
+
+&lt;!-- alert--sm: compact variant for use inside components --&gt;
+&lt;div class="alert alert--sm alert--info" role="alert"&gt;
+  &lt;div class="alert__icon"&gt;
+    &lt;i class="fa-duotone fa-sharp fa-light fa-circle-info"&gt;&lt;/i&gt;
+  &lt;/div&gt;
+  &lt;div class="alert__text"&gt;Compact message&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="lists" class="section">
+            <h1>Lists</h1>
+
+            <p>
+              Lists are default-styled, with a little extra margin and
+              line-spacing. The bullets are outside, allowing the text to align
+              with other body text.
+            </p>
+            <p>
+              Classes can be applied at the <code>ol</code> and
+              <code>ul</code> level to specify the type of number or bullet to
+              be applied: <code>list list--alpha</code> (a, b, c),
+              <code>list list--roman</code> (i, ii, iii),
+              <code>list list--circle</code>, <code>list list--disc</code>,
+              <code>list list--square</code>, <code>list list--none</code>.
+            </p>
+
+            <h2>Ordered lists</h2>
+            <h3>List 1</h3>
+            <ol>
+              <li>List item<br />multi-line</li>
+              <li>
+                List item
+                <ol class="list list--roman">
+                  <li>Nested ordered item</li>
+                  <li>Nested ordered item</li>
+                  <li>Nested ordered item</li>
+                </ol>
               </li>
-              <li class="dropdown__item" role="none">
-                <a class="dropdown__link" href="#" role="menuitem">Billing</a>
+              <li>List item</li>
+            </ol>
+
+            <h3>List 2</h3>
+            <ol>
+              <li>List item</li>
+              <li>
+                List item
+                <ul class="list list--square">
+                  <li>Nested unordered item</li>
+                  <li>Nested unordered item</li>
+                  <li>Nested unordered item</li>
+                </ul>
               </li>
-              <li class="dropdown__divider" role="separator"></li>
-              <li class="dropdown__item" role="none">
-                <a class="dropdown__link" href="#" role="menuitem">Sign out</a>
+              <li>List item</li>
+            </ol>
+
+            <h2>Unordered lists</h2>
+            <h3>List 1</h3>
+            <ul>
+              <li>List item<br />multi-line</li>
+              <li>
+                List item
+                <ul>
+                  <li>Nested item</li>
+                  <li>Nested item</li>
+                  <li>Nested item</li>
+                </ul>
+              </li>
+              <li>List item</li>
+            </ul>
+
+            <h3>List 2</h3>
+            <ul>
+              <li>List item</li>
+              <li>
+                List item
+                <ol class="list list--alpha">
+                  <li>Nested ordered item</li>
+                  <li>Nested ordered item</li>
+                  <li>Nested ordered item</li>
+                </ol>
+              </li>
+              <li>List item</li>
+            </ul>
+
+            <h2>Plain lists</h2>
+            <h3>List</h3>
+            <ul class="list list--none">
+              <li>List item</li>
+              <li>
+                List item
+                <ul class="list list--disc">
+                  <li>Nested item</li>
+                  <li>Nested item</li>
+                  <li>Nested item</li>
+                </ul>
+              </li>
+              <li>List item</li>
+            </ul>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;ol&gt;
+  &lt;li&gt;Item&lt;/li&gt;
+  &lt;li&gt;Item
+    &lt;ol class="list list--roman"&gt;
+      &lt;li&gt;Nested item&lt;/li&gt;
+    &lt;/ol&gt;
+  &lt;/li&gt;
+&lt;/ol&gt;
+
+&lt;!-- Other markers: list--alpha  list--roman  list--circle  list--disc  list--square  list--none --&gt;
+&lt;ul class="list list--none"&gt;
+  &lt;li&gt;Item&lt;/li&gt;
+  &lt;li&gt;Item&lt;/li&gt;
+&lt;/ul&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="cards" class="section">
+            <h1>Cards</h1>
+
+            <p class="mb-4">
+              Already used as an example for Colours, cards have a title and
+              body.
+            </p>
+
+            <div class="flex flex--grid">
+              <div
+                class="card flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Default</h2>
+                </div>
+                <div class="card__body">
+                  <p>The default card style.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--primary flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Primary</h2>
+                </div>
+                <div class="card__body">
+                  <p>The primary colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--secondary flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Secondary</h2>
+                </div>
+                <div class="card__body">
+                  <p>The secondary colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--info flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Information</h2>
+                </div>
+                <div class="card__body">
+                  <p>The information colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--success flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Success</h2>
+                </div>
+                <div class="card__body">
+                  <p>The success colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--warning flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Warning</h2>
+                </div>
+                <div class="card__body">
+                  <p>The warning colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--danger flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <div class="card__title">
+                  <h2>Danger</h2>
+                </div>
+                <div class="card__body">
+                  <p>The danger colour card.</p>
+                </div>
+              </div>
+            </div>
+
+            <h2>Dark variants</h2>
+
+            <p class="mb-4">
+              As with buttons, cards also come in a <code>-dark</code> variant.
+            </p>
+
+            <div class="flex flex--grid">
+              <div
+                class="card card--primary-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
+              >
+                <div class="card__title">
+                  <h2>Primary dark</h2>
+                </div>
+                <div class="card__body">
+                  <p>The dark variant of the primary colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--secondary-dark flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Secondary</h2>
+                </div>
+                <div class="card__body">
+                  <p>The dark variant of the secondary colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--info-dark flex__item flex__item--12 flex__item--6-sm flex__item--4-md"
+              >
+                <div class="card__title">
+                  <h2>Information</h2>
+                </div>
+                <div class="card__body">
+                  <p>The dark variant of the information colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--success-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
+              >
+                <div class="card__title">
+                  <h2>Success</h2>
+                </div>
+                <div class="card__body">
+                  <p>The dark variant of the success colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--warning-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
+              >
+                <div class="card__title">
+                  <h2>Warning</h2>
+                </div>
+                <div class="card__body">
+                  <p>The dark variant of the warning colour card.</p>
+                </div>
+              </div>
+
+              <div
+                class="card card--danger-dark flex__item flex__item--12 flex__item--6-sm flex__item--2-md"
+              >
+                <div class="card__title">
+                  <h2>Danger</h2>
+                </div>
+                <div class="card__body">
+                  <p>The dark variant of the danger colour card.</p>
+                </div>
+              </div>
+            </div>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="card"&gt;
+  &lt;div class="card__title"&gt;
+    &lt;h2&gt;Card title&lt;/h2&gt;
+  &lt;/div&gt;
+  &lt;div class="card__body"&gt;
+    &lt;p&gt;Card body content.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Colour variants: card--primary  card--secondary  card--info  card--success  card--warning  card--danger --&gt;
+&lt;!-- Dark variants:   card--primary-dark  card--secondary-dark  etc. --&gt;
+&lt;div class="card card--primary"&gt;
+  &lt;div class="card__title"&gt;&lt;h2&gt;Primary card&lt;/h2&gt;&lt;/div&gt;
+  &lt;div class="card__body"&gt;&lt;p&gt;Body content.&lt;/p&gt;&lt;/div&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="images" class="section">
+            <h1>Images</h1>
+
+            <p>
+              Only a few classes exist to display images, and they&rsquo;re only
+              to apply a little style around images:
+            </p>
+
+            <ul>
+              <li><code>img img--default</code>: padded with rounded border</li>
+              <li><code>img--round</code>: with <code>img</code>, circular</li>
+              <li>
+                <code>img--rounded</code>: with <code>img</code>, rounded
+                corners
+              </li>
+              <li>
+                <code>img--padded</code>: with <code>img</code>, padded, white
+                background
+              </li>
+              <li>
+                <code>img--border</code>: with <code>img</code>, grey border
               </li>
             </ul>
-          </div>
-        </div>
 
-        <p class="m-t-md">
-          Add custom dropdown arrow icons by including an element with the
-          <code>dropdown__icon</code> class inside the
-          <code>button</code> element.
-        </p>
-      </section>
+            <div class="flex flex--grid">
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--default"
+                  src="https://placebeard.it/320x240"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--default</code>
+                </figcaption>
+              </figure>
 
-      <section class="section">
-        <h1>Tooltips and Popovers</h1>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--round"
+                  src="https://placebeard.it/640x640"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--round</code>. A circle requires a square image.
+                </figcaption>
+              </figure>
 
-        <h2>Tooltips</h2>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--rounded"
+                  src="https://placebeard.it/360x270"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--rounded</code>
+                </figcaption>
+              </figure>
 
-        <p>
-          Add the <code>.tooltip</code> class and a <code>data-tooltip</code>
-          attribute directly to any interactive element. No JavaScript required.
-          The tooltip appears on hover and keyboard focus.
-        </p>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--padded"
+                  src="https://placebeard.it/480x360"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--padded</code>
+                </figcaption>
+              </figure>
 
-        <p>
-          Placement defaults to <strong>top</strong>. Use
-          <code>.tooltip--bottom</code>, <code>.tooltip--left</code>, or
-          <code>.tooltip--right</code> to change direction.
-        </p>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--round img--padded"
+                  src="https://placebeard.it/400x300"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--round img--padded</code>
+                </figcaption>
+              </figure>
 
-        <h3>Placements</h3>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--border img--padded"
+                  src="https://placebeard.it/640x480"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--border img--padded</code>
+                </figcaption>
+              </figure>
 
-        <div class="d-flex flex-wrap align-items-center gap-4">
-          <button class="button tooltip" data-tooltip="Top tooltip (default)">
-            Top (default)
-          </button>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img
+                  class="img img--border img--rounded"
+                  src="https://placebeard.it/240x180"
+                  alt=""
+                />
+                <figcaption class="text-sm text-muted">
+                  <code>img img--border img--rounded</code>
+                </figcaption>
+              </figure>
 
-          <button
-            class="button tooltip tooltip--bottom"
-            data-tooltip="Bottom tooltip"
-          >
-            Bottom
-          </button>
-
-          <button
-            class="button tooltip tooltip--left"
-            data-tooltip="Left tooltip"
-          >
-            Left
-          </button>
-
-          <button
-            class="button tooltip tooltip--right"
-            data-tooltip="Right tooltip"
-          >
-            Right
-          </button>
-        </div>
-
-        <h3>On inline text</h3>
-
-        <p>
-          Wrap an inline element to add a tooltip to a word or phrase.
-          <abbr
-            class="tooltip"
-            data-tooltip="HyperText Markup Language"
-            style="cursor: help"
-            >HTML</abbr
-          >
-          is a good candidate.
-        </p>
-
-        <h2>Popovers</h2>
-
-        <p>
-          A <code>.popover</code> wrapper contains a
-          <code>.popover__trigger</code> button and a
-          <code>.popover__panel</code>. Clicking the trigger toggles the panel;
-          <kbd>Escape</kbd> closes it and returns focus to the trigger.
-        </p>
-
-        <p>
-          Placement is set via a modifier on the panel:
-          <code>.popover__panel--top</code>, <code>.popover__panel--left</code>,
-          or <code>.popover__panel--right</code>. Default placement is
-          <strong>bottom</strong>.
-        </p>
-
-        <h3>Placements</h3>
-
-        <div class="d-flex flex-wrap align-items-center gap-4">
-          <div class="popover">
-            <button
-              class="button popover__trigger"
-              aria-expanded="false"
-              aria-controls="pop-bottom"
-              aria-haspopup="dialog"
-            >
-              Bottom (default)
-            </button>
-            <div class="popover__panel" id="pop-bottom" hidden>
-              <strong class="popover__title">Bottom popover</strong>
-              <p class="popover__body">This panel appears below the trigger.</p>
+              <figure
+                class="flex__item flex__item--12 flex__item--6-sm flex__item--3-md"
+              >
+                <img class="img" src="https://placebeard.it/520x390" alt="" />
+                <figcaption class="text-sm text-muted">
+                  <code>img</code>
+                </figcaption>
+              </figure>
             </div>
-          </div>
 
-          <div class="popover">
-            <button
-              class="button popover__trigger"
-              aria-expanded="false"
-              aria-controls="pop-top"
-              aria-haspopup="dialog"
-            >
-              Top
-            </button>
-            <div class="popover__panel popover__panel--top" id="pop-top" hidden>
-              <strong class="popover__title">Top popover</strong>
-              <p class="popover__body">This panel appears above the trigger.</p>
+            <p class="text-sm text-muted">
+              <i class="fa-duotone fa-sharp fa-light fa-asterisk"></i> Images
+              from <a href="https://placebeard.it/">placebeard.it</a>.
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;img class="img img--default" src="image.jpg" alt="Description" /&gt;
+&lt;img class="img img--round" src="square.jpg" alt="Description" /&gt;
+&lt;img class="img img--rounded" src="image.jpg" alt="Description" /&gt;
+&lt;img class="img img--padded" src="image.jpg" alt="Description" /&gt;
+&lt;img class="img img--border img--rounded" src="image.jpg" alt="Description" /&gt;
+
+&lt;figure&gt;
+  &lt;img class="img img--rounded" src="image.jpg" alt="Description" /&gt;
+  &lt;figcaption&gt;Caption text&lt;/figcaption&gt;
+&lt;/figure&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="badges" class="section">
+            <h1>Badges</h1>
+
+            <h2>Variants</h2>
+
+            <p>
+              <span class="badge">Default</span>
+              <span class="badge badge--primary">Primary</span>
+              <span class="badge badge--secondary">Secondary</span>
+              <span class="badge badge--success">Success</span>
+              <span class="badge badge--danger">Danger</span>
+              <span class="badge badge--warning">Warning</span>
+              <span class="badge badge--info">Info</span>
+              <span class="badge badge--light">Light</span>
+              <span class="badge badge--dark">Dark</span>
+            </p>
+
+            <h2>Pill</h2>
+
+            <p>Add <code>.badge--pill</code> for a rounded pill shape.</p>
+
+            <p>
+              <span class="badge badge--pill">Default</span>
+              <span class="badge badge--pill badge--primary">Primary</span>
+              <span class="badge badge--pill badge--secondary">Secondary</span>
+              <span class="badge badge--pill badge--success">Success</span>
+              <span class="badge badge--pill badge--danger">Danger</span>
+              <span class="badge badge--pill badge--warning">Warning</span>
+              <span class="badge badge--pill badge--info">Info</span>
+              <span class="badge badge--pill badge--light">Light</span>
+              <span class="badge badge--pill badge--dark">Dark</span>
+            </p>
+
+            <h2>In context</h2>
+
+            <p>
+              Badges scale to their parent element's font size and can be placed
+              inline with text.
+            </p>
+
+            <h3>In headings <span class="badge badge--primary">New</span></h3>
+
+            <h4>Subheading <span class="badge badge--secondary">Beta</span></h4>
+
+            <p>
+              Unread messages
+              <span class="badge badge--danger badge--pill">4</span>
+            </p>
+
+            <p>
+              <a href="#" class="button button--primary">
+                Notifications <span class="badge badge--light ms-1">12</span>
+              </a>
+              <a href="#" class="button button--dark">
+                Alerts
+                <span class="badge badge--pill badge--danger ms-1">3</span>
+              </a>
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — variants &amp; pill
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;span class="badge"&gt;Default&lt;/span&gt;
+&lt;span class="badge badge--primary"&gt;Primary&lt;/span&gt;
+&lt;span class="badge badge--secondary"&gt;Secondary&lt;/span&gt;
+&lt;span class="badge badge--success"&gt;Success&lt;/span&gt;
+&lt;span class="badge badge--danger"&gt;Danger&lt;/span&gt;
+&lt;span class="badge badge--warning"&gt;Warning&lt;/span&gt;
+&lt;span class="badge badge--info"&gt;Info&lt;/span&gt;
+&lt;span class="badge badge--light"&gt;Light&lt;/span&gt;
+&lt;span class="badge badge--dark"&gt;Dark&lt;/span&gt;
+
+&lt;!-- Pill shape --&gt;
+&lt;span class="badge badge--pill badge--danger"&gt;3&lt;/span&gt;</code></pre>
+              </div>
+            </details>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — in context
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;h3&gt;Heading &lt;span class="badge badge--primary"&gt;New&lt;/span&gt;&lt;/h3&gt;
+
+&lt;p&gt;Unread &lt;span class="badge badge--pill badge--danger"&gt;4&lt;/span&gt;&lt;/p&gt;
+
+&lt;a href="#" class="button button--primary"&gt;
+  Notifications &lt;span class="badge badge--light ms-1"&gt;12&lt;/span&gt;
+&lt;/a&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="modals" class="section">
+            <h1>Modals</h1>
+
+            <p>
+              Modals use the native <code>&lt;dialog&gt;</code> element with
+              <code>showModal()</code>. Use <code>data-modal-target</code> on a
+              trigger and a matching <code>id</code> on the dialog. A
+              <code>&lt;form method="dialog"&gt;</code> inside the modal closes
+              it natively via any submit button — no extra JavaScript needed.
+            </p>
+
+            <p>
+              <button
+                class="button button--primary"
+                data-modal-target="modal-basic"
+              >
+                Basic modal
+              </button>
+              <button class="button" data-modal-target="modal-sm">
+                Small modal
+              </button>
+              <button class="button" data-modal-target="modal-lg">
+                Large modal
+              </button>
+              <button class="button" data-modal-target="modal-form">
+                Modal with form
+              </button>
+              <button class="button" data-modal-target="modal-centered">
+                Centered modal
+              </button>
+            </p>
+
+            <!-- Basic modal -->
+            <dialog id="modal-basic" class="modal">
+              <form method="dialog">
+                <div class="modal__header">
+                  <h2 class="modal__title">Modal title</h2>
+                  <button class="modal__close" aria-label="Close">
+                    &times;
+                  </button>
+                </div>
+                <div class="modal__body">
+                  <p>
+                    This is a basic modal dialog. It blocks interaction with the
+                    rest of the page until dismissed.
+                  </p>
+                  <p>
+                    Click outside the modal or press <kbd>Escape</kbd> to close.
+                  </p>
+                </div>
+                <div class="modal__footer">
+                  <button type="submit" class="button">Close</button>
+                  <button type="submit" class="button button--primary">
+                    Save changes
+                  </button>
+                </div>
+              </form>
+            </dialog>
+
+            <!-- Small modal -->
+            <dialog id="modal-sm" class="modal modal--sm">
+              <form method="dialog">
+                <div class="modal__header">
+                  <h2 class="modal__title">Confirm</h2>
+                  <button class="modal__close" aria-label="Close">
+                    &times;
+                  </button>
+                </div>
+                <div class="modal__body">
+                  <p>
+                    Are you sure you want to delete this item? This action
+                    cannot be undone.
+                  </p>
+                </div>
+                <div class="modal__footer">
+                  <button type="submit" class="button">Cancel</button>
+                  <button type="submit" class="button button--danger">
+                    Delete
+                  </button>
+                </div>
+              </form>
+            </dialog>
+
+            <!-- Large modal -->
+            <dialog id="modal-lg" class="modal modal--lg">
+              <form method="dialog">
+                <div class="modal__header">
+                  <h2 class="modal__title">Terms and conditions</h2>
+                  <button class="modal__close" aria-label="Close">
+                    &times;
+                  </button>
+                </div>
+                <div class="modal__body">
+                  <p>
+                    Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed
+                    do eiusmod tempor incididunt ut labore et dolore magna
+                    aliqua.
+                  </p>
+                  <p>
+                    Ut enim ad minim veniam, quis nostrud exercitation ullamco
+                    laboris nisi ut aliquip ex ea commodo consequat.
+                  </p>
+                  <p>
+                    Duis aute irure dolor in reprehenderit in voluptate velit
+                    esse cillum dolore eu fugiat nulla pariatur.
+                  </p>
+                  <p>
+                    Excepteur sint occaecat cupidatat non proident, sunt in
+                    culpa qui officia deserunt mollit anim id est laborum.
+                  </p>
+                </div>
+                <div class="modal__footer">
+                  <button type="submit" class="button">Decline</button>
+                  <button type="submit" class="button button--primary">
+                    Accept
+                  </button>
+                </div>
+              </form>
+            </dialog>
+
+            <!-- Modal with form -->
+            <dialog id="modal-form" class="modal">
+              <form method="dialog">
+                <div class="modal__header">
+                  <h2 class="modal__title">Edit profile</h2>
+                  <button class="modal__close" aria-label="Close">
+                    &times;
+                  </button>
+                </div>
+                <div class="modal__body">
+                  <div class="form__group">
+                    <label class="form__label" for="modal-name">Name</label>
+                    <input
+                      id="modal-name"
+                      class="form__control"
+                      type="text"
+                      placeholder="Your name"
+                    />
+                  </div>
+                  <div class="form__group">
+                    <label class="form__label" for="modal-email">Email</label>
+                    <input
+                      id="modal-email"
+                      class="form__control"
+                      type="email"
+                      placeholder="your@email.com"
+                    />
+                  </div>
+                  <div class="form__group">
+                    <label class="form__label" for="modal-role">Role</label>
+                    <select id="modal-role" class="form__control">
+                      <option value="">Select a role</option>
+                      <option value="admin">Admin</option>
+                      <option value="editor">Editor</option>
+                      <option value="viewer">Viewer</option>
+                    </select>
+                  </div>
+                </div>
+                <div class="modal__footer">
+                  <button type="submit" class="button">Cancel</button>
+                  <button type="submit" class="button button--primary">
+                    Save
+                  </button>
+                </div>
+              </form>
+            </dialog>
+
+            <!-- Centered modal -->
+            <dialog id="modal-centered" class="modal modal--centered">
+              <form method="dialog">
+                <div class="modal__header">
+                  <h2 class="modal__title">Centered modal</h2>
+                  <button class="modal__close" aria-label="Close">
+                    &times;
+                  </button>
+                </div>
+                <div class="modal__body">
+                  <p>
+                    This modal uses <code>.modal--centered</code> to restore the
+                    browser's default vertical centering.
+                  </p>
+                </div>
+                <div class="modal__footer">
+                  <button type="submit" class="button button--primary">
+                    Got it
+                  </button>
+                </div>
+              </form>
+            </dialog>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — basic modal
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;button class="button button--primary" type="button" data-modal-target="my-modal"&gt;
+  Open modal
+&lt;/button&gt;
+
+&lt;dialog id="my-modal" class="modal"&gt;
+  &lt;form method="dialog"&gt;
+    &lt;div class="modal__header"&gt;
+      &lt;h2 class="modal__title"&gt;Modal title&lt;/h2&gt;
+      &lt;button class="modal__close" aria-label="Close"&gt;&amp;times;&lt;/button&gt;
+    &lt;/div&gt;
+    &lt;div class="modal__body"&gt;
+      &lt;p&gt;Modal body content.&lt;/p&gt;
+    &lt;/div&gt;
+    &lt;div class="modal__footer"&gt;
+      &lt;button type="submit" class="button"&gt;Close&lt;/button&gt;
+      &lt;button type="submit" class="button button--primary"&gt;Save changes&lt;/button&gt;
+    &lt;/div&gt;
+  &lt;/form&gt;
+&lt;/dialog&gt;
+
+&lt;!-- Size modifiers on &lt;dialog&gt;: modal--sm  modal--lg  modal--centered --&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="accordion" class="section">
+            <h1>Accordion / Disclosure</h1>
+
+            <p>
+              Built on the native <code>&lt;details&gt;</code> and
+              <code>&lt;summary&gt;</code> elements — no JavaScript required for
+              basic expand/collapse behaviour.
+            </p>
+
+            <h2>Standalone disclosure</h2>
+
+            <details class="disclosure">
+              <summary class="disclosure__trigger">What is Albert CSS?</summary>
+              <div class="disclosure__body">
+                <p>
+                  Albert CSS is a personal CSS framework based on Bootstrap v4,
+                  built with vanilla JS and no framework dependencies.
+                </p>
+              </div>
+            </details>
+
+            <details class="disclosure">
+              <summary class="disclosure__trigger">How do I use it?</summary>
+              <div class="disclosure__body">
+                <p>
+                  Include the compiled CSS and JS files in your HTML. Use the
+                  provided class names to style your components.
+                </p>
+              </div>
+            </details>
+
+            <details class="disclosure" open>
+              <summary class="disclosure__trigger">
+                This one starts open
+              </summary>
+              <div class="disclosure__body">
+                <p>
+                  Add the <code>open</code> attribute to a
+                  <code>&lt;details&gt;</code> element to have it expanded on
+                  load.
+                </p>
+              </div>
+            </details>
+
+            <h2>Accordion</h2>
+
+            <p>
+              Wrap multiple items in <code>.accordion</code> to connect them
+              visually. Each <code>.accordion__item</code> closes its siblings
+              when opened.
+            </p>
+
+            <div class="accordion">
+              <details class="accordion__item">
+                <summary class="accordion__trigger">
+                  Getting started
+                  <i
+                    class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
+                    aria-hidden="true"
+                  ></i>
+                </summary>
+                <div class="accordion__body">
+                  <p>
+                    Download or link to the CSS and JS files. No build tools
+                    required for basic usage.
+                  </p>
+                </div>
+              </details>
+              <details class="accordion__item">
+                <summary class="accordion__trigger">
+                  Customisation
+                  <i
+                    class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
+                    aria-hidden="true"
+                  ></i>
+                </summary>
+                <div class="accordion__body">
+                  <p>
+                    Override CSS custom properties in your own stylesheet to
+                    change colours, spacing, and typography without touching the
+                    source.
+                  </p>
+                </div>
+              </details>
+              <details class="accordion__item">
+                <summary class="accordion__trigger">
+                  Browser support
+                  <i
+                    class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
+                    aria-hidden="true"
+                  ></i>
+                </summary>
+                <div class="accordion__body">
+                  <p>
+                    All modern browsers. The
+                    <code>&lt;details&gt;</code> element is supported in every
+                    evergreen browser and has been since 2020.
+                  </p>
+                </div>
+              </details>
+              <details class="accordion__item">
+                <summary class="accordion__trigger">
+                  Accessibility
+                  <i
+                    class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down"
+                    aria-hidden="true"
+                  ></i>
+                </summary>
+                <div class="accordion__body">
+                  <p>
+                    <code>&lt;details&gt;</code> and
+                    <code>&lt;summary&gt;</code> are natively keyboard
+                    accessible and exposed correctly to assistive technology —
+                    no ARIA attributes required.
+                  </p>
+                </div>
+              </details>
             </div>
-          </div>
 
-          <div class="popover">
-            <button
-              class="button popover__trigger"
-              aria-expanded="false"
-              aria-controls="pop-left"
-              aria-haspopup="dialog"
-            >
-              Left
-            </button>
+            <p class="m-t-md">
+              Add custom details marker icons by including an element with the
+              <code>disclosure__icon</code> or
+              <code>accordion__icon</code> class inside the
+              <code>summary</code> element.
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — standalone disclosure
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;details class="disclosure"&gt;
+  &lt;summary class="disclosure__trigger"&gt;Trigger title&lt;/summary&gt;
+  &lt;div class="disclosure__body"&gt;
+    &lt;p&gt;Content shown when expanded.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/details&gt;
+
+&lt;!-- Add open attribute to expand on load --&gt;
+&lt;details class="disclosure" open&gt;...&lt;/details&gt;</code></pre>
+              </div>
+            </details>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — accordion group
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="accordion"&gt;
+  &lt;details class="accordion__item"&gt;
+    &lt;summary class="accordion__trigger"&gt;
+      Item 1
+      &lt;i class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down" aria-hidden="true"&gt;&lt;/i&gt;
+    &lt;/summary&gt;
+    &lt;div class="accordion__body"&gt;
+      &lt;p&gt;Content for item 1.&lt;/p&gt;
+    &lt;/div&gt;
+  &lt;/details&gt;
+  &lt;details class="accordion__item"&gt;
+    &lt;summary class="accordion__trigger"&gt;
+      Item 2
+      &lt;i class="accordion__icon fa-duotone fa-sharp fa-light fa-chevron-down" aria-hidden="true"&gt;&lt;/i&gt;
+    &lt;/summary&gt;
+    &lt;div class="accordion__body"&gt;
+      &lt;p&gt;Content for item 2.&lt;/p&gt;
+    &lt;/div&gt;
+  &lt;/details&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="tabs" class="section">
+            <h1>Tabs</h1>
+
+            <p>
+              Use <code>role="tablist"</code>, <code>role="tab"</code>, and
+              <code>role="tabpanel"</code> with matching
+              <code>aria-controls</code> / <code>id</code> pairs. The active tab
+              is indicated by <code>aria-selected="true"</code>; inactive panels
+              use the <code>hidden</code> attribute. Arrow keys,
+              <kbd>Home</kbd>, and <kbd>End</kbd> navigate between tabs.
+            </p>
+
+            <div class="tabs">
+              <div class="tabs__list" role="tablist" aria-label="Example tabs">
+                <button
+                  class="tabs__tab"
+                  role="tab"
+                  id="tab-overview"
+                  aria-controls="panel-overview"
+                  aria-selected="true"
+                  tabindex="0"
+                >
+                  Overview
+                </button>
+                <button
+                  class="tabs__tab"
+                  role="tab"
+                  id="tab-usage"
+                  aria-controls="panel-usage"
+                  aria-selected="false"
+                  tabindex="-1"
+                >
+                  Usage
+                </button>
+                <button
+                  class="tabs__tab"
+                  role="tab"
+                  id="tab-accessibility"
+                  aria-controls="panel-accessibility"
+                  aria-selected="false"
+                  tabindex="-1"
+                >
+                  Accessibility
+                </button>
+              </div>
+
+              <div
+                class="tabs__panel"
+                role="tabpanel"
+                id="panel-overview"
+                aria-labelledby="tab-overview"
+              >
+                <p>
+                  Tabs organize content into separate views where only one is
+                  visible at a time. Use them when content can be meaningfully
+                  grouped into distinct, parallel sections.
+                </p>
+              </div>
+
+              <div
+                class="tabs__panel"
+                role="tabpanel"
+                id="panel-usage"
+                aria-labelledby="tab-usage"
+                hidden
+              >
+                <p>
+                  Add <code>aria-selected="true"</code> and
+                  <code>tabindex="0"</code> to the initially active tab. All
+                  other tabs get <code>aria-selected="false"</code> and
+                  <code>tabindex="-1"</code>. Match each tab's
+                  <code>aria-controls</code> to its panel's <code>id</code>.
+                </p>
+              </div>
+
+              <div
+                class="tabs__panel"
+                role="tabpanel"
+                id="panel-accessibility"
+                aria-labelledby="tab-accessibility"
+                hidden
+              >
+                <p>
+                  The tab list follows the ARIA authoring practices
+                  roving-tabindex pattern. Only the active tab is in the tab
+                  sequence; arrow keys move focus between tabs and activate the
+                  focused tab.
+                </p>
+              </div>
+            </div>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="tabs"&gt;
+  &lt;div class="tabs__list" role="tablist" aria-label="Section tabs"&gt;
+    &lt;button class="tabs__tab" role="tab"
+      id="tab-1" aria-controls="panel-1"
+      aria-selected="true" tabindex="0"&gt;Tab 1&lt;/button&gt;
+    &lt;button class="tabs__tab" role="tab"
+      id="tab-2" aria-controls="panel-2"
+      aria-selected="false" tabindex="-1"&gt;Tab 2&lt;/button&gt;
+  &lt;/div&gt;
+  &lt;div class="tabs__panel" role="tabpanel"
+    id="panel-1" aria-labelledby="tab-1"&gt;
+    &lt;p&gt;Content for tab 1.&lt;/p&gt;
+  &lt;/div&gt;
+  &lt;div class="tabs__panel" role="tabpanel"
+    id="panel-2" aria-labelledby="tab-2" hidden&gt;
+    &lt;p&gt;Content for tab 2.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="dropdowns" class="section">
+            <h1>Dropdowns</h1>
+
+            <p>
+              A <code>.dropdown__trigger</code> button toggles a
+              <code>.dropdown__menu</code>. Arrow keys navigate items;
+              <kbd>Escape</kbd>
+              closes the menu and returns focus to the trigger.
+            </p>
+
+            <h2>Basic dropdown</h2>
+
+            <div class="dropdown">
+              <button
+                class="button dropdown__trigger"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="dropdown-basic"
+              >
+                Options
+                <i
+                  class="dropdown__icon fa-duotone fa-sharp fa-light fa-chevron-down"
+                  aria-hidden="true"
+                ></i>
+              </button>
+              <ul class="dropdown__menu" id="dropdown-basic" role="menu" hidden>
+                <li class="dropdown__item" role="none">
+                  <a class="dropdown__link" href="#" role="menuitem">Profile</a>
+                </li>
+                <li class="dropdown__item" role="none">
+                  <a class="dropdown__link" href="#" role="menuitem"
+                    >Settings</a
+                  >
+                </li>
+                <li class="dropdown__item" role="none">
+                  <button class="dropdown__button" role="menuitem" disabled>
+                    Disabled action
+                  </button>
+                </li>
+                <li class="dropdown__divider" role="separator"></li>
+                <li class="dropdown__item" role="none">
+                  <button
+                    class="dropdown__button dropdown__button--danger"
+                    role="menuitem"
+                  >
+                    Delete account
+                  </button>
+                </li>
+              </ul>
+            </div>
+
+            <div class="dropdown">
+              <button
+                class="button dropdown__trigger"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="dropdown-no-icon"
+              >
+                Options
+              </button>
+              <ul
+                class="dropdown__menu"
+                id="dropdown-no-icon"
+                role="menu"
+                hidden
+              >
+                <li class="dropdown__item" role="none">
+                  <a class="dropdown__link" href="#" role="menuitem">Profile</a>
+                </li>
+                <li class="dropdown__item" role="none">
+                  <a class="dropdown__link" href="#" role="menuitem"
+                    >Settings</a
+                  >
+                </li>
+                <li class="dropdown__item" role="none">
+                  <button class="dropdown__button" role="menuitem" disabled>
+                    Disabled action
+                  </button>
+                </li>
+                <li class="dropdown__divider" role="separator"></li>
+                <li class="dropdown__item" role="none">
+                  <button
+                    class="dropdown__button dropdown__button--danger"
+                    role="menuitem"
+                  >
+                    Delete account
+                  </button>
+                </li>
+              </ul>
+            </div>
+
+            <h2>Right-aligned dropdown</h2>
+
+            <p>
+              Add <code>.dropdown--right</code> to align the menu to the right
+              edge of the trigger.
+            </p>
+
+            <div class="text-end">
+              <div class="dropdown dropdown--right">
+                <button
+                  class="button dropdown__trigger"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  aria-controls="dropdown-right"
+                >
+                  Account
+                  <i
+                    class="dropdown__icon fa-duotone fa-sharp fa-light fa-chevron-down"
+                    aria-hidden="true"
+                  ></i>
+                </button>
+                <ul
+                  class="dropdown__menu"
+                  id="dropdown-right"
+                  role="menu"
+                  hidden
+                >
+                  <li class="dropdown__item" role="none">
+                    <a class="dropdown__link" href="#" role="menuitem"
+                      >Profile</a
+                    >
+                  </li>
+                  <li class="dropdown__item" role="none">
+                    <a class="dropdown__link" href="#" role="menuitem"
+                      >Billing</a
+                    >
+                  </li>
+                  <li class="dropdown__divider" role="separator"></li>
+                  <li class="dropdown__item" role="none">
+                    <a class="dropdown__link" href="#" role="menuitem"
+                      >Sign out</a
+                    >
+                  </li>
+                </ul>
+              </div>
+            </div>
+
+            <p class="m-t-md">
+              Add custom dropdown arrow icons by including an element with the
+              <code>dropdown__icon</code> class inside the
+              <code>button</code> element.
+            </p>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — basic dropdown
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="dropdown"&gt;
+  &lt;button class="button dropdown__trigger"
+    aria-haspopup="true" aria-expanded="false"
+    aria-controls="my-dropdown"&gt;
+    Options
+    &lt;i class="dropdown__icon fa-duotone fa-sharp fa-light fa-chevron-down" aria-hidden="true"&gt;&lt;/i&gt;
+  &lt;/button&gt;
+  &lt;ul class="dropdown__menu" id="my-dropdown" role="menu" hidden&gt;
+    &lt;li class="dropdown__item" role="none"&gt;
+      &lt;a class="dropdown__link" href="#" role="menuitem"&gt;Profile&lt;/a&gt;
+    &lt;/li&gt;
+    &lt;li class="dropdown__item" role="none"&gt;
+      &lt;button class="dropdown__button" role="menuitem" disabled&gt;Disabled action&lt;/button&gt;
+    &lt;/li&gt;
+    &lt;li class="dropdown__divider" role="separator"&gt;&lt;/li&gt;
+    &lt;li class="dropdown__item" role="none"&gt;
+      &lt;button class="dropdown__button dropdown__button--danger" role="menuitem"&gt;Delete&lt;/button&gt;
+    &lt;/li&gt;
+  &lt;/ul&gt;
+&lt;/div&gt;
+
+&lt;!-- Right-aligned: add dropdown--right to the wrapper --&gt;
+&lt;div class="dropdown dropdown--right"&gt;...&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="tooltips-popovers" class="section">
+            <h1>Tooltips and Popovers</h1>
+
+            <h2>Tooltips</h2>
+
+            <p>
+              Add the <code>.tooltip</code> class and a
+              <code>data-tooltip</code>
+              attribute directly to any interactive element. No JavaScript
+              required. The tooltip appears on hover and keyboard focus.
+            </p>
+
+            <p>
+              Placement defaults to <strong>top</strong>. Use
+              <code>.tooltip--bottom</code>, <code>.tooltip--left</code>, or
+              <code>.tooltip--right</code> to change direction.
+            </p>
+
+            <h3>Placements</h3>
+
+            <div class="d-flex flex-wrap align-items-center gap-4">
+              <button
+                class="button tooltip"
+                data-tooltip="Top tooltip (default)"
+              >
+                Top (default)
+              </button>
+
+              <button
+                class="button tooltip tooltip--bottom"
+                data-tooltip="Bottom tooltip"
+              >
+                Bottom
+              </button>
+
+              <button
+                class="button tooltip tooltip--left"
+                data-tooltip="Left tooltip"
+              >
+                Left
+              </button>
+
+              <button
+                class="button tooltip tooltip--right"
+                data-tooltip="Right tooltip"
+              >
+                Right
+              </button>
+            </div>
+
+            <h3>On inline text</h3>
+
+            <p>
+              Wrap an inline element to add a tooltip to a word or phrase.
+              <abbr
+                class="tooltip"
+                data-tooltip="HyperText Markup Language"
+                style="cursor: help"
+                >HTML</abbr
+              >
+              is a good candidate.
+            </p>
+
+            <h2>Popovers</h2>
+
+            <p>
+              A <code>.popover</code> wrapper contains a
+              <code>.popover__trigger</code> button and a
+              <code>.popover__panel</code>. Clicking the trigger toggles the
+              panel; <kbd>Escape</kbd> closes it and returns focus to the
+              trigger.
+            </p>
+
+            <p>
+              Placement is set via a modifier on the panel:
+              <code>.popover__panel--top</code>,
+              <code>.popover__panel--left</code>, or
+              <code>.popover__panel--right</code>. Default placement is
+              <strong>bottom</strong>.
+            </p>
+
+            <h3>Placements</h3>
+
+            <div class="d-flex flex-wrap align-items-center gap-4">
+              <div class="popover">
+                <button
+                  class="button popover__trigger"
+                  aria-expanded="false"
+                  aria-controls="pop-bottom"
+                  aria-haspopup="dialog"
+                >
+                  Bottom (default)
+                </button>
+                <div class="popover__panel" id="pop-bottom" hidden>
+                  <strong class="popover__title">Bottom popover</strong>
+                  <p class="popover__body">
+                    This panel appears below the trigger.
+                  </p>
+                </div>
+              </div>
+
+              <div class="popover">
+                <button
+                  class="button popover__trigger"
+                  aria-expanded="false"
+                  aria-controls="pop-top"
+                  aria-haspopup="dialog"
+                >
+                  Top
+                </button>
+                <div
+                  class="popover__panel popover__panel--top"
+                  id="pop-top"
+                  hidden
+                >
+                  <strong class="popover__title">Top popover</strong>
+                  <p class="popover__body">
+                    This panel appears above the trigger.
+                  </p>
+                </div>
+              </div>
+
+              <div class="popover">
+                <button
+                  class="button popover__trigger"
+                  aria-expanded="false"
+                  aria-controls="pop-left"
+                  aria-haspopup="dialog"
+                >
+                  Left
+                </button>
+                <div
+                  class="popover__panel popover__panel--left"
+                  id="pop-left"
+                  hidden
+                >
+                  <strong class="popover__title">Left popover</strong>
+                  <p class="popover__body">
+                    This panel appears to the left of the trigger.
+                  </p>
+                </div>
+              </div>
+
+              <div class="popover">
+                <button
+                  class="button popover__trigger"
+                  aria-expanded="false"
+                  aria-controls="pop-right"
+                  aria-haspopup="dialog"
+                >
+                  Right
+                </button>
+                <div
+                  class="popover__panel popover__panel--right"
+                  id="pop-right"
+                  hidden
+                >
+                  <strong class="popover__title">Right popover</strong>
+                  <p class="popover__body">
+                    This panel appears to the right of the trigger.
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — tooltip
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;!-- Default placement: top. Others: tooltip--bottom  tooltip--left  tooltip--right --&gt;
+&lt;button class="button tooltip" data-tooltip="Tooltip text"&gt;Hover me&lt;/button&gt;
+
+&lt;button class="button tooltip tooltip--bottom" data-tooltip="Bottom"&gt;Bottom&lt;/button&gt;</code></pre>
+              </div>
+            </details>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — popover
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="popover"&gt;
+  &lt;button class="button popover__trigger"
+    aria-expanded="false"
+    aria-controls="my-popover"
+    aria-haspopup="dialog"&gt;
+    Open popover
+  &lt;/button&gt;
+  &lt;div class="popover__panel" id="my-popover" hidden&gt;
+    &lt;strong class="popover__title"&gt;Popover title&lt;/strong&gt;
+    &lt;p class="popover__body"&gt;Popover body content.&lt;/p&gt;
+  &lt;/div&gt;
+&lt;/div&gt;
+
+&lt;!-- Panel placement modifiers: popover__panel--top  popover__panel--left  popover__panel--right --&gt;
+&lt;!-- Default placement: bottom --&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="spacing" class="section">
+            <h1>Utilities</h1>
+
+            <p>
+              Some utility classes are available to handle specific needs, not
+              handled by other components.
+            </p>
+
+            <h2>Spacing</h2>
+
+            <p>
+              Pattern: <code>.{m|p}{axis}{n}</code> — margin or padding, axis,
+              and a numeric scale where each step is 0.25rem (0–8, reaching
+              2rem). Uses CSS logical properties, so axes respect writing
+              direction.
+            </p>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Axis</th>
+                  <th>Margin</th>
+                  <th>Padding</th>
+                  <th>Property</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>(none)</td>
+                  <td><code>m-{n}</code></td>
+                  <td><code>p-{n}</code></td>
+                  <td>all sides</td>
+                </tr>
+                <tr>
+                  <td><code>t</code></td>
+                  <td><code>mt-{n}</code></td>
+                  <td><code>pt-{n}</code></td>
+                  <td><code>block-start</code> (top in LTR)</td>
+                </tr>
+                <tr>
+                  <td><code>b</code></td>
+                  <td><code>mb-{n}</code></td>
+                  <td><code>pb-{n}</code></td>
+                  <td><code>block-end</code> (bottom in LTR)</td>
+                </tr>
+                <tr>
+                  <td><code>s</code></td>
+                  <td><code>ms-{n}</code></td>
+                  <td><code>ps-{n}</code></td>
+                  <td><code>inline-start</code> (left in LTR)</td>
+                </tr>
+                <tr>
+                  <td><code>e</code></td>
+                  <td><code>me-{n}</code></td>
+                  <td><code>pe-{n}</code></td>
+                  <td><code>inline-end</code> (right in LTR)</td>
+                </tr>
+                <tr>
+                  <td><code>x</code></td>
+                  <td><code>mx-{n}</code></td>
+                  <td><code>px-{n}</code></td>
+                  <td><code>inline</code> (left + right in LTR)</td>
+                </tr>
+                <tr>
+                  <td><code>y</code></td>
+                  <td><code>my-{n}</code></td>
+                  <td><code>py-{n}</code></td>
+                  <td><code>block</code> (top + bottom in LTR)</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p>
+              Scale: <code>0</code>=0 &nbsp; <code>1</code>=0.25rem &nbsp;
+              <code>2</code>=0.5rem &nbsp; <code>3</code>=0.75rem &nbsp;
+              <code>4</code>=1rem &nbsp; <code>5</code>=1.25rem &nbsp;
+              <code>6</code>=1.5rem &nbsp; <code>7</code>=1.75rem &nbsp;
+              <code>8</code>=2rem
+            </p>
+
+            <p>
+              Auto margin utilities: <code>mx-auto</code>, <code>my-auto</code>,
+              <code>ms-auto</code>, <code>me-auto</code>, <code>mt-auto</code>,
+              <code>mb-auto</code>.
+            </p>
+
+            <p>For example:</p>
+
+            <ul>
+              <li>2rem top margin: <code>mt-8</code></li>
+              <li>1.5rem inline-end (right) padding: <code>pe-6</code></li>
+              <li>1rem horizontal margins: <code>mx-4</code></li>
+              <li>0.5rem vertical padding: <code>py-2</code></li>
+              <li>0.25rem inline-start (left) padding: <code>ps-1</code></li>
+              <li>No padding: <code>p-0</code></li>
+            </ul>
+
+            <h3>Legacy utilities</h3>
+
+            <div class="alert alert--warning alert--sm" role="alert">
+              <div class="alert__icon">
+                <i
+                  class="fa-duotone fa-sharp fa-light fa-triangle-exclamation"
+                ></i>
+              </div>
+              <div class="alert__text">
+                These utilities are deprecated and will be removed in a future
+                version.
+              </div>
+            </div>
+
+            <p>
+              The original spacing classes remain available. Pattern:
+              <code>.{m|p}-{side}-{size}</code>. Sides: <code>t</code> (top),
+              <code>b</code> (bottom), <code>l</code> (left),
+              <code>r</code> (right), <code>h</code> (left + right),
+              <code>v</code> (top + bottom). Sizes: <code>xs</code> (0.25rem),
+              <code>sm</code> (0.5rem), <code>md</code> (1rem),
+              <code>lg</code> (1.5rem), <code>xl</code> (2rem).
+            </p>
+
+            <ul>
+              <li>2rem top margin: <code>m-t-xl</code></li>
+              <li>1.5rem right padding: <code>p-r-lg</code></li>
+              <li>1rem horizontal margins: <code>m-h-md</code></li>
+              <li>0.5rem vertical padding: <code>p-v-sm</code></li>
+              <li>No padding: <code>p-0</code></li>
+            </ul>
+          </section>
+
+          <section id="text" class="section">
+            <h2>Text</h2>
+
+            <p>
+              Text utilities can be used on both block-level and inline
+              elements.
+            </p>
+
+            <p>
+              Text colour utilities match the alerts, buttons and cards colours:
+            </p>
+
+            <p class="text-primary">
+              Primary colour text using <code>class="text-primary"</code>.
+            </p>
+
+            <p class="text-secondary">
+              Secondary colour text using <code>class="text-secondary"</code>.
+            </p>
+
+            <p class="text-info">
+              Information colour text using <code>class="text-info"</code>.
+            </p>
+
+            <p class="text-success">
+              Success colour text using <code>class="text-success"</code>.
+            </p>
+
+            <p class="text-warning">
+              Warning colour text using <code>class="text-warning"</code>.
+            </p>
+
+            <p class="text-danger">
+              Danger colour text using <code>class="text-danger"</code>.
+            </p>
+
+            <p class="text-muted">
+              Muted colour text using <code>class="text-muted"</code>.
+            </p>
+
+            <h3>Background colour</h3>
+
+            <p>
+              Use <code>text-bg-*</code> to set both background and a
+              theme-aware contrasting text colour in one class:
+            </p>
+
+            <div class="d-flex flex-wrap gap-3 mt-4">
+              <div class="text-bg-primary text-xs p-3 rounded">
+                text-bg-primary
+              </div>
+              <div class="text-bg-secondary text-xs p-3 rounded">
+                text-bg-secondary
+              </div>
+              <div class="text-bg-info text-xs p-3 rounded">text-bg-info</div>
+              <div class="text-bg-success text-xs p-3 rounded">
+                text-bg-success
+              </div>
+              <div class="text-bg-warning text-xs p-3 rounded">
+                text-bg-warning
+              </div>
+              <div class="text-bg-danger text-xs p-3 rounded">
+                text-bg-danger
+              </div>
+            </div>
+
+            <p class="mt-4">
+              Use <code>bg-*</code> alone when you only need the background:
+            </p>
+
+            <div class="d-flex flex-wrap gap-3 mt-4">
+              <div class="bg-primary text-white text-xs p-3 rounded">
+                bg-primary
+              </div>
+              <div class="bg-secondary text-white text-xs p-3 rounded">
+                bg-secondary
+              </div>
+              <div class="bg-info text-white text-xs p-3 rounded">bg-info</div>
+              <div class="bg-success text-white text-xs p-3 rounded">
+                bg-success
+              </div>
+              <div class="bg-warning text-white text-xs p-3 rounded">
+                bg-warning
+              </div>
+              <div class="bg-danger text-white text-xs p-3 rounded">
+                bg-danger
+              </div>
+              <div class="bg-muted text-xs p-3 rounded">bg-muted</div>
+              <div class="bg-dark text-white text-xs p-3 rounded">bg-dark</div>
+              <div class="bg-white text-xs p-3 rounded border">bg-white</div>
+              <div class="bg-transparent text-xs p-3 rounded border">
+                bg-transparent
+              </div>
+            </div>
+
+            <h3>Text size</h3>
+
+            <p>
+              Font size utilities use a
+              <a href="https://tailwindcss.com/docs/font-size"
+                >Tailwind-style</a
+              >
+              scale with paired <code>line-height</code> values (all in
+              <code>rem</code>):
+            </p>
+
+            <p class="text-xs">
+              Extra small text using <code>class="text-xs"</code> (0.75rem).
+            </p>
+            <p class="text-sm">
+              Small text using <code>class="text-sm"</code> (0.875rem).
+            </p>
+            <p class="text-base">
+              Base text using <code>class="text-base"</code> (1rem).
+            </p>
+            <p class="text-lg">
+              Large text using <code>class="text-lg"</code> (1.125rem).
+            </p>
+            <p class="text-xl">
+              Extra large text using <code>class="text-xl"</code> (1.25rem).
+            </p>
+            <p class="text-2xl">
+              2× large text using <code>class="text-2xl"</code> (1.5rem).
+            </p>
+
+            <h3 class="mt-5">Text alignment</h3>
+
+            <p>
+              <code>text-start</code>, <code>text-center</code>, and
+              <code>text-end</code> use CSS logical values and respect writing
+              direction.
+            </p>
+
+            <p class="text-start">
+              Left-aligned text (<code>text-start</code>).
+            </p>
+            <p class="text-center">Centred text (<code>text-center</code>).</p>
+            <p class="text-end">Right-aligned text (<code>text-end</code>).</p>
+
+            <h3>Other text utilities</h3>
+
+            <h4 class="fw-normal">
+              &ldquo;Normal&rdquo; weight <code>h4</code> heading with
+              <code>class="fw-normal"</code>. It can be used to reset font
+              weight in headings or bold text.
+            </h4>
+
+            <p>
+              <span class="fw-bold">
+                Bold text using <code>class="fw-bold"</code>. It&rsquo;s not
+                quite as bold as <code>&lt;strong&gt;</code> </span
+              >.<br />
+              <strong>Strong text, for reference.</strong>
+            </p>
+
+            <p class="fw-light">
+              Light text using <code>class="fw-light"</code>.
+            </p>
+
+            <p>
+              <span class="text-uppercase"
+                >Uppercase text using <code>class="text-uppercase"</code></span
+              >. For example, use it with <code>text-sm</code> and
+              <code>fw-light</code> for
+              <span class="text-uppercase fw-light text-sm">fun variations</span
+              >.
+            </p>
+          </section>
+
+          <section id="display" class="section">
+            <h2>Display</h2>
+
+            <h3>Display values</h3>
+
+            <p>
+              Set the <code>display</code> property directly with a utility
+              class.
+            </p>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Property</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>d-none</code></td>
+                  <td><code>display: none</code></td>
+                </tr>
+                <tr>
+                  <td><code>d-block</code></td>
+                  <td><code>display: block</code></td>
+                </tr>
+                <tr>
+                  <td><code>d-inline</code></td>
+                  <td><code>display: inline</code></td>
+                </tr>
+                <tr>
+                  <td><code>d-inline-block</code></td>
+                  <td><code>display: inline-block</code></td>
+                </tr>
+                <tr>
+                  <td><code>d-flex</code></td>
+                  <td><code>display: flex</code></td>
+                </tr>
+                <tr>
+                  <td><code>d-inline-flex</code></td>
+                  <td><code>display: inline-flex</code></td>
+                </tr>
+                <tr>
+                  <td><code>d-grid</code></td>
+                  <td><code>display: grid</code></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>Flex helpers</h3>
+
+            <p>
+              Use alongside <code>d-flex</code> or <code>d-inline-flex</code> to
+              control direction, wrapping, alignment, and justification.
+            </p>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Property</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>flex-row</code></td>
+                  <td><code>flex-direction: row</code></td>
+                </tr>
+                <tr>
+                  <td><code>flex-column</code></td>
+                  <td><code>flex-direction: column</code></td>
+                </tr>
+                <tr>
+                  <td><code>flex-wrap</code></td>
+                  <td><code>flex-wrap: wrap</code></td>
+                </tr>
+                <tr>
+                  <td><code>flex-nowrap</code></td>
+                  <td><code>flex-wrap: nowrap</code></td>
+                </tr>
+                <tr>
+                  <td><code>align-items-start</code></td>
+                  <td><code>align-items: flex-start</code></td>
+                </tr>
+                <tr>
+                  <td><code>align-items-end</code></td>
+                  <td><code>align-items: flex-end</code></td>
+                </tr>
+                <tr>
+                  <td><code>align-items-center</code></td>
+                  <td><code>align-items: center</code></td>
+                </tr>
+                <tr>
+                  <td><code>align-items-stretch</code></td>
+                  <td><code>align-items: stretch</code></td>
+                </tr>
+                <tr>
+                  <td><code>align-items-baseline</code></td>
+                  <td><code>align-items: baseline</code></td>
+                </tr>
+                <tr>
+                  <td><code>justify-content-start</code></td>
+                  <td><code>justify-content: flex-start</code></td>
+                </tr>
+                <tr>
+                  <td><code>justify-content-end</code></td>
+                  <td><code>justify-content: flex-end</code></td>
+                </tr>
+                <tr>
+                  <td><code>justify-content-center</code></td>
+                  <td><code>justify-content: center</code></td>
+                </tr>
+                <tr>
+                  <td><code>justify-content-between</code></td>
+                  <td><code>justify-content: space-between</code></td>
+                </tr>
+                <tr>
+                  <td><code>justify-content-around</code></td>
+                  <td><code>justify-content: space-around</code></td>
+                </tr>
+                <tr>
+                  <td><code>justify-content-evenly</code></td>
+                  <td><code>justify-content: space-evenly</code></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>Gap</h3>
+
+            <p>
+              Set <code>gap</code>, <code>column-gap</code>, or
+              <code>row-gap</code>
+              on flex and grid containers. Same 0–8 scale as spacing (n ×
+              0.25rem).
+            </p>
+
+            <ul>
+              <li><code>gap-{n}</code> — both axes</li>
+              <li><code>gap-x-{n}</code> — columns only</li>
+              <li><code>gap-y-{n}</code> — rows only</li>
+            </ul>
+          </section>
+
+          <section id="overflow" class="section">
+            <h2>Overflow</h2>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Property</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>overflow-auto</code></td>
+                  <td><code>overflow: auto</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-hidden</code></td>
+                  <td><code>overflow: hidden</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-visible</code></td>
+                  <td><code>overflow: visible</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-scroll</code></td>
+                  <td><code>overflow: scroll</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-clip</code></td>
+                  <td><code>overflow: clip</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-x-auto</code></td>
+                  <td><code>overflow-x: auto</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-x-hidden</code></td>
+                  <td><code>overflow-x: hidden</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-x-scroll</code></td>
+                  <td><code>overflow-x: scroll</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-y-auto</code></td>
+                  <td><code>overflow-y: auto</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-y-hidden</code></td>
+                  <td><code>overflow-y: hidden</code></td>
+                </tr>
+                <tr>
+                  <td><code>overflow-y-scroll</code></td>
+                  <td><code>overflow-y: scroll</code></td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="position" class="section">
+            <h2>Position</h2>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Property</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>position-static</code></td>
+                  <td><code>position: static</code></td>
+                </tr>
+                <tr>
+                  <td><code>position-relative</code></td>
+                  <td><code>position: relative</code></td>
+                </tr>
+                <tr>
+                  <td><code>position-absolute</code></td>
+                  <td><code>position: absolute</code></td>
+                </tr>
+                <tr>
+                  <td><code>position-fixed</code></td>
+                  <td><code>position: fixed</code></td>
+                </tr>
+                <tr>
+                  <td><code>position-sticky</code></td>
+                  <td><code>position: sticky</code></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>Sticky helpers</h3>
+
+            <p>
+              <code>sticky-top</code> and <code>sticky-bottom</code> apply
+              <code>position: sticky</code> with a fixed edge and a default
+              <code>z-index</code> of 100.
+            </p>
+
+            <h3>Edge placement</h3>
+
+            <p>
+              Use with <code>position-absolute</code> or
+              <code>position-fixed</code> to anchor an element to an edge of its
+              container. Values: <code>0</code>, <code>50%</code>,
+              <code>100%</code>.
+            </p>
+
+            <ul>
+              <li><code>top-{0|50|100}</code></li>
+              <li><code>bottom-{0|50|100}</code></li>
+              <li>
+                <code>start-{0|50|100}</code> — <code>inset-inline-start</code>
+              </li>
+              <li>
+                <code>end-{0|50|100}</code> — <code>inset-inline-end</code>
+              </li>
+            </ul>
+
+            <p>
+              Add <code>translate-middle</code> alongside
+              <code>top-50 start-50</code>
+              to centre an absolutely-positioned element within its parent.
+            </p>
+
             <div
-              class="popover__panel popover__panel--left"
-              id="pop-left"
-              hidden
+              class="position-relative border"
+              style="height: 6rem; background: var(--grey100)"
             >
-              <strong class="popover__title">Left popover</strong>
-              <p class="popover__body">
-                This panel appears to the left of the trigger.
-              </p>
+              <span
+                class="position-absolute top-0 start-0 badge badge--secondary"
+                >top / start</span
+              >
+              <span class="position-absolute top-0 end-0 badge badge--secondary"
+                >top / end</span
+              >
+              <span
+                class="position-absolute top-50 start-50 translate-middle badge badge--primary"
+                >centre</span
+              >
+              <span
+                class="position-absolute bottom-0 start-0 badge badge--secondary"
+                >bottom / start</span
+              >
+              <span
+                class="position-absolute bottom-0 end-0 badge badge--secondary"
+                >bottom / end</span
+              >
             </div>
-          </div>
+          </section>
 
-          <div class="popover">
-            <button
-              class="button popover__trigger"
-              aria-expanded="false"
-              aria-controls="pop-right"
-              aria-haspopup="dialog"
-            >
-              Right
-            </button>
-            <div
-              class="popover__panel popover__panel--right"
-              id="pop-right"
-              hidden
-            >
-              <strong class="popover__title">Right popover</strong>
-              <p class="popover__body">
-                This panel appears to the right of the trigger.
-              </p>
+          <section id="shadows" class="section">
+            <h2>Shadows</h2>
+
+            <p>
+              Box-shadow utility scale — values use <code>px</code> as is
+              standard for decorative effects.
+            </p>
+
+            <div class="d-flex flex-wrap gap-4 mt-4">
+              <div class="shadow-sm p-4 rounded">shadow-sm</div>
+              <div class="shadow p-4 rounded">shadow</div>
+              <div class="shadow-md p-4 rounded">shadow-md</div>
+              <div class="shadow-lg p-4 rounded">shadow-lg</div>
+              <div class="shadow-xl p-4 rounded">shadow-xl</div>
+              <div class="shadow-inner p-4 rounded">shadow-inner</div>
+              <div class="shadow-none border p-4 rounded">shadow-none</div>
             </div>
-          </div>
-        </div>
-      </section>
-
-      <section class="section">
-        <h1>Utilities</h1>
-
-        <p>
-          Some utility classes are available to handle specific needs, not
-          handled by other components.
-        </p>
-
-        <h2>Spacing</h2>
-
-        <p>
-          Pattern: <code>.{m|p}{axis}{n}</code> — margin or padding, axis, and a
-          numeric scale where each step is 0.25rem (0–8, reaching 2rem). Uses
-          CSS logical properties, so axes respect writing direction.
-        </p>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Axis</th>
-              <th>Margin</th>
-              <th>Padding</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td>(none)</td>
-              <td><code>m-{n}</code></td>
-              <td><code>p-{n}</code></td>
-              <td>all sides</td>
-            </tr>
-            <tr>
-              <td><code>t</code></td>
-              <td><code>mt-{n}</code></td>
-              <td><code>pt-{n}</code></td>
-              <td><code>block-start</code> (top in LTR)</td>
-            </tr>
-            <tr>
-              <td><code>b</code></td>
-              <td><code>mb-{n}</code></td>
-              <td><code>pb-{n}</code></td>
-              <td><code>block-end</code> (bottom in LTR)</td>
-            </tr>
-            <tr>
-              <td><code>s</code></td>
-              <td><code>ms-{n}</code></td>
-              <td><code>ps-{n}</code></td>
-              <td><code>inline-start</code> (left in LTR)</td>
-            </tr>
-            <tr>
-              <td><code>e</code></td>
-              <td><code>me-{n}</code></td>
-              <td><code>pe-{n}</code></td>
-              <td><code>inline-end</code> (right in LTR)</td>
-            </tr>
-            <tr>
-              <td><code>x</code></td>
-              <td><code>mx-{n}</code></td>
-              <td><code>px-{n}</code></td>
-              <td><code>inline</code> (left + right in LTR)</td>
-            </tr>
-            <tr>
-              <td><code>y</code></td>
-              <td><code>my-{n}</code></td>
-              <td><code>py-{n}</code></td>
-              <td><code>block</code> (top + bottom in LTR)</td>
-            </tr>
-          </tbody>
-        </table>
-
-        <p>
-          Scale: <code>0</code>=0 &nbsp; <code>1</code>=0.25rem &nbsp;
-          <code>2</code>=0.5rem &nbsp; <code>3</code>=0.75rem &nbsp;
-          <code>4</code>=1rem &nbsp; <code>5</code>=1.25rem &nbsp;
-          <code>6</code>=1.5rem &nbsp; <code>7</code>=1.75rem &nbsp;
-          <code>8</code>=2rem
-        </p>
-
-        <p>
-          Auto margin utilities: <code>mx-auto</code>, <code>my-auto</code>,
-          <code>ms-auto</code>, <code>me-auto</code>, <code>mt-auto</code>,
-          <code>mb-auto</code>.
-        </p>
-
-        <p>For example:</p>
-
-        <ul>
-          <li>2rem top margin: <code>mt-8</code></li>
-          <li>1.5rem inline-end (right) padding: <code>pe-6</code></li>
-          <li>1rem horizontal margins: <code>mx-4</code></li>
-          <li>0.5rem vertical padding: <code>py-2</code></li>
-          <li>0.25rem inline-start (left) padding: <code>ps-1</code></li>
-          <li>No padding: <code>p-0</code></li>
-        </ul>
-
-        <h3>Legacy utilities</h3>
-
-        <div class="alert alert--warning alert--sm" role="alert">
-          <div class="alert__icon">
-            <i class="fa-duotone fa-sharp fa-light fa-triangle-exclamation"></i>
-          </div>
-          <div class="alert__text">
-            These utilities are deprecated and will be removed in a future
-            version.
-          </div>
-        </div>
-
-        <p>
-          The original spacing classes remain available. Pattern:
-          <code>.{m|p}-{side}-{size}</code>. Sides: <code>t</code> (top),
-          <code>b</code> (bottom), <code>l</code> (left),
-          <code>r</code> (right), <code>h</code> (left + right),
-          <code>v</code> (top + bottom). Sizes: <code>xs</code> (0.25rem),
-          <code>sm</code> (0.5rem), <code>md</code> (1rem),
-          <code>lg</code> (1.5rem), <code>xl</code> (2rem).
-        </p>
-
-        <ul>
-          <li>2rem top margin: <code>m-t-xl</code></li>
-          <li>1.5rem right padding: <code>p-r-lg</code></li>
-          <li>1rem horizontal margins: <code>m-h-md</code></li>
-          <li>0.5rem vertical padding: <code>p-v-sm</code></li>
-          <li>No padding: <code>p-0</code></li>
-        </ul>
-      </section>
-
-      <section class="section">
-        <h2>Text</h2>
-
-        <p>
-          Text utilities can be used on both block-level and inline elements.
-        </p>
-
-        <p>
-          Text colour utilities match the alerts, buttons and cards colours:
-        </p>
-
-        <p class="text-primary">
-          Primary colour text using <code>class="text-primary"</code>.
-        </p>
-
-        <p class="text-secondary">
-          Secondary colour text using <code>class="text-secondary"</code>.
-        </p>
-
-        <p class="text-info">
-          Information colour text using <code>class="text-info"</code>.
-        </p>
-
-        <p class="text-success">
-          Success colour text using <code>class="text-success"</code>.
-        </p>
-
-        <p class="text-warning">
-          Warning colour text using <code>class="text-warning"</code>.
-        </p>
-
-        <p class="text-danger">
-          Danger colour text using <code>class="text-danger"</code>.
-        </p>
-
-        <p class="text-muted">
-          Muted colour text using <code>class="text-muted"</code>.
-        </p>
-
-        <h3>Background colour</h3>
-
-        <p>
-          Use <code>text-bg-*</code> to set both background and a theme-aware
-          contrasting text colour in one class:
-        </p>
-
-        <div class="d-flex flex-wrap gap-3 mt-4">
-          <div class="text-bg-primary text-xs p-3 rounded">text-bg-primary</div>
-          <div class="text-bg-secondary text-xs p-3 rounded">
-            text-bg-secondary
-          </div>
-          <div class="text-bg-info text-xs p-3 rounded">text-bg-info</div>
-          <div class="text-bg-success text-xs p-3 rounded">text-bg-success</div>
-          <div class="text-bg-warning text-xs p-3 rounded">text-bg-warning</div>
-          <div class="text-bg-danger text-xs p-3 rounded">text-bg-danger</div>
-        </div>
-
-        <p class="mt-4">
-          Use <code>bg-*</code> alone when you only need the background:
-        </p>
-
-        <div class="d-flex flex-wrap gap-3 mt-4">
-          <div class="bg-primary text-white text-xs p-3 rounded">
-            bg-primary
-          </div>
-          <div class="bg-secondary text-white text-xs p-3 rounded">
-            bg-secondary
-          </div>
-          <div class="bg-info text-white text-xs p-3 rounded">bg-info</div>
-          <div class="bg-success text-white text-xs p-3 rounded">
-            bg-success
-          </div>
-          <div class="bg-warning text-white text-xs p-3 rounded">
-            bg-warning
-          </div>
-          <div class="bg-danger text-white text-xs p-3 rounded">bg-danger</div>
-          <div class="bg-muted text-xs p-3 rounded">bg-muted</div>
-          <div class="bg-dark text-white text-xs p-3 rounded">bg-dark</div>
-          <div class="bg-white text-xs p-3 rounded border">bg-white</div>
-          <div class="bg-transparent text-xs p-3 rounded border">
-            bg-transparent
-          </div>
-        </div>
-
-        <h3>Text size</h3>
-
-        <p>
-          Font size utilities use a
-          <a href="https://tailwindcss.com/docs/font-size">Tailwind-style</a>
-          scale with paired <code>line-height</code> values (all in
-          <code>rem</code>):
-        </p>
-
-        <p class="text-xs">
-          Extra small text using <code>class="text-xs"</code> (0.75rem).
-        </p>
-        <p class="text-sm">
-          Small text using <code>class="text-sm"</code> (0.875rem).
-        </p>
-        <p class="text-base">
-          Base text using <code>class="text-base"</code> (1rem).
-        </p>
-        <p class="text-lg">
-          Large text using <code>class="text-lg"</code> (1.125rem).
-        </p>
-        <p class="text-xl">
-          Extra large text using <code>class="text-xl"</code> (1.25rem).
-        </p>
-        <p class="text-2xl">
-          2× large text using <code>class="text-2xl"</code> (1.5rem).
-        </p>
-
-        <h3 class="mt-5">Text alignment</h3>
-
-        <p>
-          <code>text-start</code>, <code>text-center</code>, and
-          <code>text-end</code> use CSS logical values and respect writing
-          direction.
-        </p>
-
-        <p class="text-start">Left-aligned text (<code>text-start</code>).</p>
-        <p class="text-center">Centred text (<code>text-center</code>).</p>
-        <p class="text-end">Right-aligned text (<code>text-end</code>).</p>
-
-        <h3>Other text utilities</h3>
-
-        <h4 class="fw-normal">
-          &ldquo;Normal&rdquo; weight <code>h4</code> heading with
-          <code>class="fw-normal"</code>. It can be used to reset font weight in
-          headings or bold text.
-        </h4>
-
-        <p>
-          <span class="fw-bold">
-            Bold text using <code>class="fw-bold"</code>. It&rsquo;s not quite
-            as bold as <code>&lt;strong&gt;</code> </span
-          >.<br />
-          <strong>Strong text, for reference.</strong>
-        </p>
-
-        <p class="fw-light">Light text using <code>class="fw-light"</code>.</p>
-
-        <p>
-          <span class="text-uppercase"
-            >Uppercase text using <code>class="text-uppercase"</code></span
-          >. For example, use it with <code>text-sm</code> and
-          <code>fw-light</code> for
-          <span class="text-uppercase fw-light text-sm">fun variations</span>.
-        </p>
-      </section>
-
-      <section class="section">
-        <h2>Display</h2>
-
-        <h3>Display values</h3>
-
-        <p>
-          Set the <code>display</code> property directly with a utility class.
-        </p>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>d-none</code></td>
-              <td><code>display: none</code></td>
-            </tr>
-            <tr>
-              <td><code>d-block</code></td>
-              <td><code>display: block</code></td>
-            </tr>
-            <tr>
-              <td><code>d-inline</code></td>
-              <td><code>display: inline</code></td>
-            </tr>
-            <tr>
-              <td><code>d-inline-block</code></td>
-              <td><code>display: inline-block</code></td>
-            </tr>
-            <tr>
-              <td><code>d-flex</code></td>
-              <td><code>display: flex</code></td>
-            </tr>
-            <tr>
-              <td><code>d-inline-flex</code></td>
-              <td><code>display: inline-flex</code></td>
-            </tr>
-            <tr>
-              <td><code>d-grid</code></td>
-              <td><code>display: grid</code></td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h3>Flex helpers</h3>
-
-        <p>
-          Use alongside <code>d-flex</code> or <code>d-inline-flex</code> to
-          control direction, wrapping, alignment, and justification.
-        </p>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>flex-row</code></td>
-              <td><code>flex-direction: row</code></td>
-            </tr>
-            <tr>
-              <td><code>flex-column</code></td>
-              <td><code>flex-direction: column</code></td>
-            </tr>
-            <tr>
-              <td><code>flex-wrap</code></td>
-              <td><code>flex-wrap: wrap</code></td>
-            </tr>
-            <tr>
-              <td><code>flex-nowrap</code></td>
-              <td><code>flex-wrap: nowrap</code></td>
-            </tr>
-            <tr>
-              <td><code>align-items-start</code></td>
-              <td><code>align-items: flex-start</code></td>
-            </tr>
-            <tr>
-              <td><code>align-items-end</code></td>
-              <td><code>align-items: flex-end</code></td>
-            </tr>
-            <tr>
-              <td><code>align-items-center</code></td>
-              <td><code>align-items: center</code></td>
-            </tr>
-            <tr>
-              <td><code>align-items-stretch</code></td>
-              <td><code>align-items: stretch</code></td>
-            </tr>
-            <tr>
-              <td><code>align-items-baseline</code></td>
-              <td><code>align-items: baseline</code></td>
-            </tr>
-            <tr>
-              <td><code>justify-content-start</code></td>
-              <td><code>justify-content: flex-start</code></td>
-            </tr>
-            <tr>
-              <td><code>justify-content-end</code></td>
-              <td><code>justify-content: flex-end</code></td>
-            </tr>
-            <tr>
-              <td><code>justify-content-center</code></td>
-              <td><code>justify-content: center</code></td>
-            </tr>
-            <tr>
-              <td><code>justify-content-between</code></td>
-              <td><code>justify-content: space-between</code></td>
-            </tr>
-            <tr>
-              <td><code>justify-content-around</code></td>
-              <td><code>justify-content: space-around</code></td>
-            </tr>
-            <tr>
-              <td><code>justify-content-evenly</code></td>
-              <td><code>justify-content: space-evenly</code></td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h3>Gap</h3>
-
-        <p>
-          Set <code>gap</code>, <code>column-gap</code>, or <code>row-gap</code>
-          on flex and grid containers. Same 0–8 scale as spacing (n × 0.25rem).
-        </p>
-
-        <ul>
-          <li><code>gap-{n}</code> — both axes</li>
-          <li><code>gap-x-{n}</code> — columns only</li>
-          <li><code>gap-y-{n}</code> — rows only</li>
-        </ul>
-      </section>
-
-      <section class="section">
-        <h2>Overflow</h2>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>overflow-auto</code></td>
-              <td><code>overflow: auto</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-hidden</code></td>
-              <td><code>overflow: hidden</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-visible</code></td>
-              <td><code>overflow: visible</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-scroll</code></td>
-              <td><code>overflow: scroll</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-clip</code></td>
-              <td><code>overflow: clip</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-x-auto</code></td>
-              <td><code>overflow-x: auto</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-x-hidden</code></td>
-              <td><code>overflow-x: hidden</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-x-scroll</code></td>
-              <td><code>overflow-x: scroll</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-y-auto</code></td>
-              <td><code>overflow-y: auto</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-y-hidden</code></td>
-              <td><code>overflow-y: hidden</code></td>
-            </tr>
-            <tr>
-              <td><code>overflow-y-scroll</code></td>
-              <td><code>overflow-y: scroll</code></td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <section class="section">
-        <h2>Position</h2>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Property</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>position-static</code></td>
-              <td><code>position: static</code></td>
-            </tr>
-            <tr>
-              <td><code>position-relative</code></td>
-              <td><code>position: relative</code></td>
-            </tr>
-            <tr>
-              <td><code>position-absolute</code></td>
-              <td><code>position: absolute</code></td>
-            </tr>
-            <tr>
-              <td><code>position-fixed</code></td>
-              <td><code>position: fixed</code></td>
-            </tr>
-            <tr>
-              <td><code>position-sticky</code></td>
-              <td><code>position: sticky</code></td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h3>Sticky helpers</h3>
-
-        <p>
-          <code>sticky-top</code> and <code>sticky-bottom</code> apply
-          <code>position: sticky</code> with a fixed edge and a default
-          <code>z-index</code> of 100.
-        </p>
-
-        <h3>Edge placement</h3>
-
-        <p>
-          Use with <code>position-absolute</code> or
-          <code>position-fixed</code> to anchor an element to an edge of its
-          container. Values: <code>0</code>, <code>50%</code>,
-          <code>100%</code>.
-        </p>
-
-        <ul>
-          <li><code>top-{0|50|100}</code></li>
-          <li><code>bottom-{0|50|100}</code></li>
-          <li>
-            <code>start-{0|50|100}</code> — <code>inset-inline-start</code>
-          </li>
-          <li><code>end-{0|50|100}</code> — <code>inset-inline-end</code></li>
-        </ul>
-
-        <p>
-          Add <code>translate-middle</code> alongside
-          <code>top-50 start-50</code>
-          to centre an absolutely-positioned element within its parent.
-        </p>
-
-        <div
-          class="position-relative border"
-          style="height: 6rem; background: var(--grey100)"
-        >
-          <span class="position-absolute top-0 start-0 badge badge--secondary"
-            >top / start</span
-          >
-          <span class="position-absolute top-0 end-0 badge badge--secondary"
-            >top / end</span
-          >
-          <span
-            class="position-absolute top-50 start-50 translate-middle badge badge--primary"
-            >centre</span
-          >
-          <span
-            class="position-absolute bottom-0 start-0 badge badge--secondary"
-            >bottom / start</span
-          >
-          <span class="position-absolute bottom-0 end-0 badge badge--secondary"
-            >bottom / end</span
-          >
-        </div>
-      </section>
-
-      <section class="section">
-        <h2>Shadows</h2>
-
-        <p>
-          Box-shadow utility scale — values use <code>px</code> as is standard
-          for decorative effects.
-        </p>
-
-        <div class="d-flex flex-wrap gap-4 mt-4">
-          <div class="shadow-sm p-4 rounded">shadow-sm</div>
-          <div class="shadow p-4 rounded">shadow</div>
-          <div class="shadow-md p-4 rounded">shadow-md</div>
-          <div class="shadow-lg p-4 rounded">shadow-lg</div>
-          <div class="shadow-xl p-4 rounded">shadow-xl</div>
-          <div class="shadow-inner p-4 rounded">shadow-inner</div>
-          <div class="shadow-none border p-4 rounded">shadow-none</div>
-        </div>
-      </section>
-
-      <section class="section">
-        <h2>Borders</h2>
-
-        <h3>Adding borders</h3>
-
-        <p>
-          <code>border</code> adds a 1px border on all sides using
-          <code>var(--grey300)</code>. Individual sides use logical properties.
-        </p>
-
-        <div class="d-flex flex-wrap gap-4 mt-4">
-          <div class="border p-3">border</div>
-          <div class="border-top p-3">border-top</div>
-          <div class="border-bottom p-3">border-bottom</div>
-          <div class="border-start p-3">border-start</div>
-          <div class="border-end p-3">border-end</div>
-        </div>
-
-        <h3>Border colours</h3>
-
-        <div class="d-flex flex-wrap gap-4 mt-4">
-          <div class="border border-primary p-3">primary</div>
-          <div class="border border-secondary p-3">secondary</div>
-          <div class="border border-success p-3">success</div>
-          <div class="border border-info p-3">info</div>
-          <div class="border border-warning p-3">warning</div>
-          <div class="border border-danger p-3">danger</div>
-        </div>
-
-        <h3>Border width</h3>
-
-        <div class="d-flex flex-wrap gap-4 mt-4">
-          <div class="border border-1 p-3">border-1</div>
-          <div class="border border-2 p-3">border-2</div>
-          <div class="border border-3 p-3">border-3</div>
-          <div class="border border-4 p-3">border-4</div>
-        </div>
-
-        <h3>Border radius</h3>
-
-        <div class="d-flex flex-wrap gap-4 mt-4">
-          <div class="border rounded-0 p-3">rounded-0</div>
-          <div class="border rounded-sm p-3">rounded-sm</div>
-          <div class="border rounded p-3">rounded</div>
-          <div class="border rounded-lg p-3">rounded-lg</div>
-          <div class="border rounded-xl p-3">rounded-xl</div>
-          <div class="border rounded-xxl p-3">rounded-xxl</div>
-          <div class="border rounded-pill px-4 py-3">rounded-pill</div>
-          <div
-            class="border rounded-full d-grid place-items-center p-3"
-            style="width: 4rem; height: 4rem"
-          >
-            rounded-full
-          </div>
-        </div>
-      </section>
-
-      <section class="section">
-        <h2>Z-index</h2>
-
-        <h3>Numeric scale</h3>
-
-        <p>
-          General-purpose scale for stacking elements within a component. Use
-          with <code>position-relative</code> or <code>position-absolute</code>.
-        </p>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Value</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>z-0</code></td>
-              <td><code>0</code></td>
-            </tr>
-            <tr>
-              <td><code>z-10</code></td>
-              <td><code>10</code></td>
-            </tr>
-            <tr>
-              <td><code>z-20</code></td>
-              <td><code>20</code></td>
-            </tr>
-            <tr>
-              <td><code>z-30</code></td>
-              <td><code>30</code></td>
-            </tr>
-            <tr>
-              <td><code>z-40</code></td>
-              <td><code>40</code></td>
-            </tr>
-            <tr>
-              <td><code>z-50</code></td>
-              <td><code>50</code></td>
-            </tr>
-            <tr>
-              <td><code>z-auto</code></td>
-              <td><code>auto</code></td>
-            </tr>
-          </tbody>
-        </table>
-
-        <h3>Semantic scale</h3>
-
-        <p>
-          Named values that match the layering used by framework components.
-        </p>
-
-        <table class="table table--striped table--sm">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Value</th>
-              <th>Used by</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>z-above</code></td>
-              <td><code>10</code></td>
-              <td>Above normal flow</td>
-            </tr>
-            <tr>
-              <td><code>z-raised</code></td>
-              <td><code>100</code></td>
-              <td>Raised elements</td>
-            </tr>
-            <tr>
-              <td><code>z-dropdown</code></td>
-              <td><code>1000</code></td>
-              <td>Dropdown</td>
-            </tr>
-            <tr>
-              <td><code>z-sticky</code></td>
-              <td><code>1020</code></td>
-              <td><code>sticky-top</code>, <code>sticky-bottom</code></td>
-            </tr>
-            <tr>
-              <td><code>z-fixed</code></td>
-              <td><code>1030</code></td>
-              <td>Fixed headers/footers</td>
-            </tr>
-            <tr>
-              <td><code>z-backdrop</code></td>
-              <td><code>1040</code></td>
-              <td>Modal backdrop</td>
-            </tr>
-            <tr>
-              <td><code>z-modal</code></td>
-              <td><code>1050</code></td>
-              <td>Modal</td>
-            </tr>
-            <tr>
-              <td><code>z-popover</code></td>
-              <td><code>1060</code></td>
-              <td>Popover</td>
-            </tr>
-            <tr>
-              <td><code>z-tooltip</code></td>
-              <td><code>1070</code></td>
-              <td>Tooltip</td>
-            </tr>
-          </tbody>
-        </table>
-      </section>
-
-      <section class="section">
-        <h2>Aspect ratio</h2>
-
-        <p>
-          Apply <code>ratio</code> to a wrapper element, then add a modifier for
-          the desired ratio. The direct child (iframe, img, video, etc.) is
-          stretched to fill the container via absolute positioning.
-        </p>
-
-        <pre><code>&lt;div class="ratio ratio--16x9"&gt;
+          </section>
+
+          <section id="borders" class="section">
+            <h2>Borders</h2>
+
+            <h3>Adding borders</h3>
+
+            <p>
+              <code>border</code> adds a 1px border on all sides using
+              <code>var(--grey300)</code>. Individual sides use logical
+              properties.
+            </p>
+
+            <div class="d-flex flex-wrap gap-4 mt-4">
+              <div class="border p-3">border</div>
+              <div class="border-top p-3">border-top</div>
+              <div class="border-bottom p-3">border-bottom</div>
+              <div class="border-start p-3">border-start</div>
+              <div class="border-end p-3">border-end</div>
+            </div>
+
+            <h3>Border colours</h3>
+
+            <div class="d-flex flex-wrap gap-4 mt-4">
+              <div class="border border-primary p-3">primary</div>
+              <div class="border border-secondary p-3">secondary</div>
+              <div class="border border-success p-3">success</div>
+              <div class="border border-info p-3">info</div>
+              <div class="border border-warning p-3">warning</div>
+              <div class="border border-danger p-3">danger</div>
+            </div>
+
+            <h3>Border width</h3>
+
+            <div class="d-flex flex-wrap gap-4 mt-4">
+              <div class="border border-1 p-3">border-1</div>
+              <div class="border border-2 p-3">border-2</div>
+              <div class="border border-3 p-3">border-3</div>
+              <div class="border border-4 p-3">border-4</div>
+            </div>
+
+            <h3>Border radius</h3>
+
+            <div class="d-flex flex-wrap gap-4 mt-4">
+              <div class="border rounded-0 p-3">rounded-0</div>
+              <div class="border rounded-sm p-3">rounded-sm</div>
+              <div class="border rounded p-3">rounded</div>
+              <div class="border rounded-lg p-3">rounded-lg</div>
+              <div class="border rounded-xl p-3">rounded-xl</div>
+              <div class="border rounded-xxl p-3">rounded-xxl</div>
+              <div class="border rounded-pill px-4 py-3">rounded-pill</div>
+              <div
+                class="border rounded-full d-grid place-items-center p-3"
+                style="width: 4rem; height: 4rem"
+              >
+                rounded-full
+              </div>
+            </div>
+          </section>
+
+          <section id="z-index" class="section">
+            <h2>Z-index</h2>
+
+            <h3>Numeric scale</h3>
+
+            <p>
+              General-purpose scale for stacking elements within a component.
+              Use with <code>position-relative</code> or
+              <code>position-absolute</code>.
+            </p>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Value</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>z-0</code></td>
+                  <td><code>0</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-10</code></td>
+                  <td><code>10</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-20</code></td>
+                  <td><code>20</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-30</code></td>
+                  <td><code>30</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-40</code></td>
+                  <td><code>40</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-50</code></td>
+                  <td><code>50</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-auto</code></td>
+                  <td><code>auto</code></td>
+                </tr>
+              </tbody>
+            </table>
+
+            <h3>Semantic scale</h3>
+
+            <p>
+              Named values that match the layering used by framework components.
+            </p>
+
+            <table class="table table--striped table--sm">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Value</th>
+                  <th>Used by</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>z-above</code></td>
+                  <td><code>10</code></td>
+                  <td>Above normal flow</td>
+                </tr>
+                <tr>
+                  <td><code>z-raised</code></td>
+                  <td><code>100</code></td>
+                  <td>Raised elements</td>
+                </tr>
+                <tr>
+                  <td><code>z-dropdown</code></td>
+                  <td><code>1000</code></td>
+                  <td>Dropdown</td>
+                </tr>
+                <tr>
+                  <td><code>z-sticky</code></td>
+                  <td><code>1020</code></td>
+                  <td><code>sticky-top</code>, <code>sticky-bottom</code></td>
+                </tr>
+                <tr>
+                  <td><code>z-fixed</code></td>
+                  <td><code>1030</code></td>
+                  <td>Fixed headers/footers</td>
+                </tr>
+                <tr>
+                  <td><code>z-backdrop</code></td>
+                  <td><code>1040</code></td>
+                  <td>Modal backdrop</td>
+                </tr>
+                <tr>
+                  <td><code>z-modal</code></td>
+                  <td><code>1050</code></td>
+                  <td>Modal</td>
+                </tr>
+                <tr>
+                  <td><code>z-popover</code></td>
+                  <td><code>1060</code></td>
+                  <td>Popover</td>
+                </tr>
+                <tr>
+                  <td><code>z-tooltip</code></td>
+                  <td><code>1070</code></td>
+                  <td>Tooltip</td>
+                </tr>
+              </tbody>
+            </table>
+          </section>
+
+          <section id="aspect-ratio" class="section">
+            <h2>Aspect ratio</h2>
+
+            <p>
+              Apply <code>ratio</code> to a wrapper element, then add a modifier
+              for the desired ratio. The direct child (iframe, img, video, etc.)
+              is stretched to fill the container via absolute positioning.
+            </p>
+
+            <pre><code>&lt;div class="ratio ratio--16x9"&gt;
   &lt;iframe src="..." title="..."&gt;&lt;/iframe&gt;
 &lt;/div&gt;</code></pre>
 
-        <table class="table table--striped table--sm mt-4">
-          <thead>
-            <tr>
-              <th>Class</th>
-              <th>Ratio</th>
-              <th>Common use</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr>
-              <td><code>ratio--1x1</code></td>
-              <td>1:1</td>
-              <td>Square thumbnails, avatars</td>
-            </tr>
-            <tr>
-              <td><code>ratio--4x3</code></td>
-              <td>4:3</td>
-              <td>Standard SD video</td>
-            </tr>
-            <tr>
-              <td><code>ratio--3x2</code></td>
-              <td>3:2</td>
-              <td>Photography</td>
-            </tr>
-            <tr>
-              <td><code>ratio--16x9</code></td>
-              <td>16:9</td>
-              <td>HD video, embeds</td>
-            </tr>
-            <tr>
-              <td><code>ratio--21x9</code></td>
-              <td>21:9</td>
-              <td>Cinematic / wide banners</td>
-            </tr>
-            <tr>
-              <td><code>ratio--9x16</code></td>
-              <td>9:16</td>
-              <td>Vertical / portrait video</td>
-            </tr>
-          </tbody>
-        </table>
+            <table class="table table--striped table--sm mt-4">
+              <thead>
+                <tr>
+                  <th>Class</th>
+                  <th>Ratio</th>
+                  <th>Common use</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td><code>ratio--1x1</code></td>
+                  <td>1:1</td>
+                  <td>Square thumbnails, avatars</td>
+                </tr>
+                <tr>
+                  <td><code>ratio--4x3</code></td>
+                  <td>4:3</td>
+                  <td>Standard SD video</td>
+                </tr>
+                <tr>
+                  <td><code>ratio--3x2</code></td>
+                  <td>3:2</td>
+                  <td>Photography</td>
+                </tr>
+                <tr>
+                  <td><code>ratio--16x9</code></td>
+                  <td>16:9</td>
+                  <td>HD video, embeds</td>
+                </tr>
+                <tr>
+                  <td><code>ratio--21x9</code></td>
+                  <td>21:9</td>
+                  <td>Cinematic / wide banners</td>
+                </tr>
+                <tr>
+                  <td><code>ratio--9x16</code></td>
+                  <td>9:16</td>
+                  <td>Vertical / portrait video</td>
+                </tr>
+              </tbody>
+            </table>
 
-        <h3>Examples</h3>
+            <h3>Examples</h3>
 
-        <div class="d-flex flex-wrap gap-4 align-items-start mt-4">
-          <div style="width: 10rem">
-            <div class="ratio ratio--1x1 bg-muted">
-              <div
-                class="d-flex align-items-center justify-content-center text-muted text-sm"
-              >
-                1×1
+            <div class="d-flex flex-wrap gap-4 align-items-start mt-4">
+              <div style="width: 10rem">
+                <div class="ratio ratio--1x1 bg-muted">
+                  <div
+                    class="d-flex align-items-center justify-content-center text-muted text-sm"
+                  >
+                    1×1
+                  </div>
+                </div>
+                <p class="text-center text-sm mt-2"><code>ratio--1x1</code></p>
+              </div>
+              <div style="width: 14rem">
+                <div class="ratio ratio--4x3 bg-muted">
+                  <div
+                    class="d-flex align-items-center justify-content-center text-muted text-sm"
+                  >
+                    4×3
+                  </div>
+                </div>
+                <p class="text-center text-sm mt-2"><code>ratio--4x3</code></p>
+              </div>
+              <div style="width: 16rem">
+                <div class="ratio ratio--16x9 bg-muted">
+                  <div
+                    class="d-flex align-items-center justify-content-center text-muted text-sm"
+                  >
+                    16×9
+                  </div>
+                </div>
+                <p class="text-center text-sm mt-2"><code>ratio--16x9</code></p>
+              </div>
+              <div style="width: 20rem">
+                <div class="ratio ratio--21x9 bg-muted">
+                  <div
+                    class="d-flex align-items-center justify-content-center text-muted text-sm"
+                  >
+                    21×9
+                  </div>
+                </div>
+                <p class="text-center text-sm mt-2"><code>ratio--21x9</code></p>
               </div>
             </div>
-            <p class="text-center text-sm mt-2"><code>ratio--1x1</code></p>
-          </div>
-          <div style="width: 14rem">
-            <div class="ratio ratio--4x3 bg-muted">
+
+            <details class="sg-snippet">
+              <summary>
+                HTML
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;!-- Ratios: ratio--1x1  ratio--4x3  ratio--3x2  ratio--16x9  ratio--21x9  ratio--9x16 --&gt;
+&lt;div class="ratio ratio--16x9"&gt;
+  &lt;iframe src="https://..." title="Video"&gt;&lt;/iframe&gt;
+&lt;/div&gt;</code></pre>
+              </div>
+            </details>
+          </section>
+
+          <section id="grid" class="section">
+            <h2>Grid</h2>
+
+            <p>
+              <code>grid</code> sets a 12-column CSS grid. Use
+              <code>grid-cols-{n}</code> for equal-width columns, or
+              <code>col-{n}</code> to span a specific number of columns. Combine
+              with <code>gap-*</code> for gutters.
+            </p>
+
+            <h3>Equal-width columns</h3>
+
+            <p>
+              <code>grid grid-cols-{n}</code> — each child fills one column:
+            </p>
+
+            <div class="grid grid-cols-2 gap-3 mt-4">
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+            </div>
+
+            <div class="grid grid-cols-3 gap-3 mt-3">
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+            </div>
+
+            <div class="grid grid-cols-4 gap-3 mt-3">
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+              <div class="bg-muted p-3 rounded text-center text-sm">col</div>
+            </div>
+
+            <h3>Column spans</h3>
+
+            <p>
+              Use <code>col-{n}</code> on children of a
+              <code>grid</code> container to span a specific number of the 12
+              columns:
+            </p>
+
+            <div class="grid gap-3 mt-4">
               <div
-                class="d-flex align-items-center justify-content-center text-muted text-sm"
+                class="col-12 text-bg-secondary p-3 rounded text-center text-sm"
               >
-                4×3
+                col-12
+              </div>
+              <div class="col-6 bg-muted p-3 rounded text-center text-sm">
+                col-6
+              </div>
+              <div class="col-6 bg-muted p-3 rounded text-center text-sm">
+                col-6
+              </div>
+              <div class="col-8 bg-muted p-3 rounded text-center text-sm">
+                col-8
+              </div>
+              <div class="col-4 bg-muted p-3 rounded text-center text-sm">
+                col-4
+              </div>
+              <div class="col-4 bg-muted p-3 rounded text-center text-sm">
+                col-4
+              </div>
+              <div class="col-4 bg-muted p-3 rounded text-center text-sm">
+                col-4
+              </div>
+              <div class="col-4 bg-muted p-3 rounded text-center text-sm">
+                col-4
+              </div>
+              <div class="col-3 bg-muted p-3 rounded text-center text-sm">
+                col-3
+              </div>
+              <div class="col-3 bg-muted p-3 rounded text-center text-sm">
+                col-3
+              </div>
+              <div class="col-3 bg-muted p-3 rounded text-center text-sm">
+                col-3
+              </div>
+              <div class="col-3 bg-muted p-3 rounded text-center text-sm">
+                col-3
               </div>
             </div>
-            <p class="text-center text-sm mt-2"><code>ratio--4x3</code></p>
-          </div>
-          <div style="width: 16rem">
-            <div class="ratio ratio--16x9 bg-muted">
-              <div
-                class="d-flex align-items-center justify-content-center text-muted text-sm"
-              >
-                16×9
+
+            <h3>Row and full-width helpers</h3>
+
+            <ul>
+              <li>
+                <code>col-full</code> — spans all 12 columns (<code>1 / -1</code
+                >)
+              </li>
+              <li><code>col-auto</code> — auto-sized column</li>
+              <li><code>row-span-{1–6}</code> — span multiple rows</li>
+              <li><code>row-span-full</code> — span all rows</li>
+            </ul>
+
+            <h3>Cell alignment</h3>
+
+            <ul>
+              <li>
+                <code>place-items-{center|start|end|stretch}</code> — align all
+                cells within the grid
+              </li>
+              <li>
+                <code>place-self-{center|start|end|stretch}</code> — align a
+                single cell within its area
+              </li>
+            </ul>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — equal-width columns
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="grid grid-cols-3 gap-4"&gt;
+  &lt;div&gt;Column 1&lt;/div&gt;
+  &lt;div&gt;Column 2&lt;/div&gt;
+  &lt;div&gt;Column 3&lt;/div&gt;
+&lt;/div&gt;</code></pre>
               </div>
-            </div>
-            <p class="text-center text-sm mt-2"><code>ratio--16x9</code></p>
-          </div>
-          <div style="width: 20rem">
-            <div class="ratio ratio--21x9 bg-muted">
-              <div
-                class="d-flex align-items-center justify-content-center text-muted text-sm"
-              >
-                21×9
+            </details>
+
+            <details class="sg-snippet">
+              <summary>
+                HTML — column spans
+                <i
+                  class="fa-light fa-chevron-right sg-snippet__chevron"
+                  aria-hidden="true"
+                ></i>
+              </summary>
+              <div class="sg-snippet__code">
+                <button
+                  class="sg-snippet__copy button button--sm"
+                  aria-label="Copy code"
+                  type="button"
+                >
+                  Copy
+                </button>
+                <pre><code>&lt;div class="grid gap-4"&gt;
+  &lt;div class="col-8"&gt;8 of 12 columns&lt;/div&gt;
+  &lt;div class="col-4"&gt;4 of 12 columns&lt;/div&gt;
+  &lt;div class="col-6"&gt;Half width&lt;/div&gt;
+  &lt;div class="col-6"&gt;Half width&lt;/div&gt;
+&lt;/div&gt;</code></pre>
               </div>
-            </div>
-            <p class="text-center text-sm mt-2"><code>ratio--21x9</code></p>
-          </div>
+            </details>
+          </section>
         </div>
-      </section>
-
-      <section class="section">
-        <h2>Grid</h2>
-
-        <p>
-          <code>grid</code> sets a 12-column CSS grid. Use
-          <code>grid-cols-{n}</code> for equal-width columns, or
-          <code>col-{n}</code> to span a specific number of columns. Combine
-          with <code>gap-*</code> for gutters.
-        </p>
-
-        <h3>Equal-width columns</h3>
-
-        <p><code>grid grid-cols-{n}</code> — each child fills one column:</p>
-
-        <div class="grid grid-cols-2 gap-3 mt-4">
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-        </div>
-
-        <div class="grid grid-cols-3 gap-3 mt-3">
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-        </div>
-
-        <div class="grid grid-cols-4 gap-3 mt-3">
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-          <div class="bg-muted p-3 rounded text-center text-sm">col</div>
-        </div>
-
-        <h3>Column spans</h3>
-
-        <p>
-          Use <code>col-{n}</code> on children of a <code>grid</code> container
-          to span a specific number of the 12 columns:
-        </p>
-
-        <div class="grid gap-3 mt-4">
-          <div class="col-12 text-bg-secondary p-3 rounded text-center text-sm">
-            col-12
-          </div>
-          <div class="col-6 bg-muted p-3 rounded text-center text-sm">
-            col-6
-          </div>
-          <div class="col-6 bg-muted p-3 rounded text-center text-sm">
-            col-6
-          </div>
-          <div class="col-8 bg-muted p-3 rounded text-center text-sm">
-            col-8
-          </div>
-          <div class="col-4 bg-muted p-3 rounded text-center text-sm">
-            col-4
-          </div>
-          <div class="col-4 bg-muted p-3 rounded text-center text-sm">
-            col-4
-          </div>
-          <div class="col-4 bg-muted p-3 rounded text-center text-sm">
-            col-4
-          </div>
-          <div class="col-4 bg-muted p-3 rounded text-center text-sm">
-            col-4
-          </div>
-          <div class="col-3 bg-muted p-3 rounded text-center text-sm">
-            col-3
-          </div>
-          <div class="col-3 bg-muted p-3 rounded text-center text-sm">
-            col-3
-          </div>
-          <div class="col-3 bg-muted p-3 rounded text-center text-sm">
-            col-3
-          </div>
-          <div class="col-3 bg-muted p-3 rounded text-center text-sm">
-            col-3
-          </div>
-        </div>
-
-        <h3>Row and full-width helpers</h3>
-
-        <ul>
-          <li>
-            <code>col-full</code> — spans all 12 columns (<code>1 / -1</code>)
-          </li>
-          <li><code>col-auto</code> — auto-sized column</li>
-          <li><code>row-span-{1–6}</code> — span multiple rows</li>
-          <li><code>row-span-full</code> — span all rows</li>
-        </ul>
-
-        <h3>Cell alignment</h3>
-
-        <ul>
-          <li>
-            <code>place-items-{center|start|end|stretch}</code> — align all
-            cells within the grid
-          </li>
-          <li>
-            <code>place-self-{center|start|end|stretch}</code> — align a single
-            cell within its area
-          </li>
-        </ul>
-      </section>
+        <!-- /.sg-content -->
+      </div>
+      <!-- /.layout-sidebar -->
     </main>
 
     <script>
@@ -3191,6 +4487,66 @@
             .forEach((el) => el.classList.add('d-none'));
         });
       });
+
+      // Copy buttons
+      document.querySelectorAll('.sg-snippet__copy').forEach((btn) => {
+        btn.addEventListener('click', () => {
+          const code = btn.closest('.sg-snippet__code').querySelector('code');
+          navigator.clipboard.writeText(code.textContent).then(() => {
+            const orig = btn.textContent;
+            btn.textContent = 'Copied!';
+            setTimeout(() => {
+              btn.textContent = orig;
+            }, 1500);
+          });
+        });
+      });
+
+      // Active nav highlight on scroll
+      const sgNavLinks = [
+        ...document.querySelectorAll('.sg-nav__link[href^="#"]'),
+      ];
+      const sgSections = [...document.querySelectorAll('section[id]')];
+
+      function updateActiveNav() {
+        const headerH =
+          parseFloat(
+            getComputedStyle(document.documentElement).getPropertyValue(
+              '--headerHeight',
+            ),
+          ) || 57;
+        const threshold = headerH + 20;
+        let active = null;
+        for (const section of sgSections) {
+          if (section.getBoundingClientRect().top <= threshold) {
+            active = section;
+          } else {
+            break;
+          }
+        }
+        sgNavLinks.forEach((l) =>
+          l.classList.toggle(
+            'is-active',
+            active ? l.getAttribute('href') === `#${active.id}` : false,
+          ),
+        );
+      }
+
+      let sgScrollTicking = false;
+      document.addEventListener(
+        'scroll',
+        () => {
+          if (!sgScrollTicking) {
+            requestAnimationFrame(() => {
+              updateActiveNav();
+              sgScrollTicking = false;
+            });
+            sgScrollTicking = true;
+          }
+        },
+        { passive: true },
+      );
+      updateActiveNav();
     </script>
   </body>
 </html>

--- a/versions.html
+++ b/versions.html
@@ -3,11 +3,16 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Albert CSS — Version Index</title>
+    <title>Albert CSS — Version History</title>
     <link
       rel="stylesheet"
       href="https://www.craigmcn.com/albertcss/css/albert.min.css"
     />
+    <script
+      src="https://kit.fontawesome.com/453b852cdd.js"
+      crossorigin="anonymous"
+      defer
+    ></script>
     <style>
       .version-card + .version-card {
         margin-top: 1.5rem;
@@ -59,19 +64,49 @@
       </div>
 
       <h1>
-        <a href="https://www.craigmcn.com/albertcss/">Albert CSS</a>
+        <a href="./">Albert CSS</a>
       </h1>
+
+      <nav class="nav" aria-label="Site navigation">
+        <ul class="nav__list">
+          <li class="nav__item">
+            <a class="nav__link" href="./">Style Guide</a>
+          </li>
+          <li class="nav__item">
+            <a class="nav__link" href="versions.html">Versions</a>
+          </li>
+        </ul>
+      </nav>
     </header>
 
     <main class="main">
       <div class="container">
-        <h1>Version Index</h1>
+        <div
+          class="alert alert--warning"
+          role="alert"
+          style="margin-block-start: 1.5rem"
+        >
+          <div class="alert__icon">
+            <i
+              class="fa-duotone fa-sharp fa-light fa-2xl fa-triangle-exclamation"
+            ></i>
+          </div>
+          <div class="alert__text">
+            <strong>URL update:</strong> The canonical URL for the latest
+            release is now
+            <code>https://albertcss.craigmcn.com/css/albert.min.css</code>. The
+            <code>https://www.craigmcn.com/albertcss/</code> URL continues to
+            work, but consider updating your references.
+          </div>
+        </div>
+
+        <h1>Version History</h1>
 
         <section>
           <h2>Latest</h2>
           <p>
-            Served by Netlify — always the most recent release. No SRI hash; use
-            a pinned version below for integrity-protected loads.
+            Always the most recent release. No SRI hash; use a pinned version
+            below for integrity-protected loads.
           </p>
           <div class="card">
             <div class="card__body">
@@ -95,6 +130,12 @@
               >
                 Copy both
               </button>
+              <p class="text-muted text-sm mt-2">
+                Legacy URL also works:
+                <code
+                  >https://www.craigmcn.com/albertcss/css/albert.min.css</code
+                >
+              </p>
             </div>
           </div>
         </section>
@@ -114,8 +155,8 @@
     </main>
 
     <script>
-      var LATEST_CSS = 'https://www.craigmcn.com/albertcss/css/albert.min.css';
-      var LATEST_JS = 'https://www.craigmcn.com/albertcss/js/albert.min.js';
+      var LATEST_CSS = 'https://albertcss.craigmcn.com/css/albert.min.css';
+      var LATEST_JS = 'https://albertcss.craigmcn.com/js/albert.min.js';
       var latestCssTag = '<link rel="stylesheet" href="' + LATEST_CSS + '">';
       var latestJsTag = '<script src="' + LATEST_JS + '" defer><' + '/script>';
       var latestBoth = latestCssTag + '\n' + latestJsTag;


### PR DESCRIPTION
## Summary

- Adds HTML copy-snippet drawers to the style guide (`src/index.html`) for all components and utilities, so users can copy-paste markup directly
- Restructures the two-URL setup: `albertcss.craigmcn.com` (GitHub Pages) becomes the canonical home with the full style guide + snippets; `www.craigmcn.com/albertcss/` (Netlify) serves a snippet-less style guide + latest CSS/JS for backward compat
- Moves the versions page from `index.html` → `versions.html`, adds a URL-update warning and nav links; style guide side nav gains a "Version history" link
- Release workflow now deploys `dist/` to both the versioned path _and_ the gh-pages root, so `albertcss.craigmcn.com/css/albert.min.css` serves the latest release
- Gulpfile `stripSnippets()` transform removes `<details class="sg-snippet">` elements, their CSS, and the dead copy-button JS from the Netlify HTML output (no new dependencies — uses Node's built-in `Transform` stream)

## Test plan

- [ ] `yarn build` — confirm `dist/index.html` contains `<details class="sg-snippet">` elements (snippets present)
- [ ] `yarn build:netlify` — confirm `netlify/albertcss/index.html` has zero `sg-snippet` references
- [ ] `yarn serve` — open `localhost:3020`, verify style guide loads and "Version history" appears at the bottom of the side nav
- [ ] `versions.html` renders correctly: FA warning icon, nav links to Style Guide / Versions, `albertcss.craigmcn.com` URLs in the Latest section
- [ ] After next release: `albertcss.craigmcn.com/` serves the style guide; `albertcss.craigmcn.com/versions.html` shows the versions page; `albertcss.craigmcn.com/css/albert.min.css` returns CSS

🤖 Generated with [Claude Code](https://claude.com/claude-code)