### PR TITLE
fix: dark mode toggle, nav links, and page title

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,7 @@ src/
 │   ├── scripts.js            # Entry point — imports all modules
 │   ├── accordion.js          # Accordion/disclosure component
 │   ├── alerts.js             # Alert close/remove behaviour
+│   ├── darkMode.js           # Dark mode toggle (html[data-mode], data-color spans)
 │   ├── dropdown.js           # Dropdown menu toggle
 │   ├── menuToggle.js         # Responsive nav toggle, aria-expanded
 │   ├── modal.js              # Modal open/close, focus trap
@@ -201,13 +202,16 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 - **Repo hygiene**: `.github/CODEOWNERS` (`* @craigmcn`), branch protection ruleset (1 approval, Admin bypass, `test` status check, block force push + deletion) — both already in place, confirmed 2026-05-01
 - **Yarn 3.3.1 → 4 + Husky** (PR #291, merged 2026-05-20): Yarn 4.14.1 via Corepack, Husky pre-commit hook, full Prettier reformat
 - **SRI + versions index** (PR #295, merged 2026-05-20): SRI hashes computed at release time, `versions.json` upserted on `gh-pages`, `versions.html` page with copy buttons
-- **gh-pages canonical site + HTML snippets** (PR #303, open 2026-05-28): style guide restructured with sidebar nav and `<details class="sg-snippet">` copy drawers per component; `versions.html` at repo root with URL-update warning; `versions.html` linked from side nav; `stripSnippets()` Transform in gulpfile strips drawers for Netlify build; release workflow deploys `dist/` to gh-pages root so `albertcss.craigmcn.com/css/albert.min.css` works after next release; new layout partials (`_container.scss`, `_sidebar-layout.scss`, `_sections--divided`)
+- **gh-pages canonical site + HTML snippets** (PR #303, merged 2026-05-28): style guide restructured with sidebar nav and `<details class="sg-snippet">` copy drawers per component; `versions.html` at repo root with URL-update warning; `versions.html` linked from side nav; `stripSnippets()` Transform in gulpfile strips drawers for Netlify build; release workflow deploys `dist/` to gh-pages root so `albertcss.craigmcn.com/css/albert.min.css` works after next release; new layout partials (`_container.scss`, `_sidebar-layout.scss`, `_sections--divided`)
+- **Dark mode toggle + nav fixes** (PR #304, open 2026-05-28): add `darkMode.js` module (`initDarkMode()`), rename title/h1 "Style Guide" → "Albert CSS", replace placeholder nav links with "Style Guide" (`./`) and "Versions" (absolute gh-pages URL); 7 new unit tests
 
 ### In progress / next steps
 
-- Merge PR #303 and trigger a release — first release after merge completes the gh-pages restructuring (style guide at root, latest CSS/JS at `albertcss.craigmcn.com/`)
+- **Merge PR #304** (fix/dark-mode-nav) — dark mode toggle, nav, title fixes; [#304](https://github.com/craigmcn/albertcss/pull/304)
+- **Trigger a release** after PR #304 merges — first release since PR #303 will update `albertcss.craigmcn.com/` root with new `index.html` (snippets, dark mode, correct nav)
 - Add Vitest unit test for `stripSnippets()` to catch regex regressions (flagged in PR #303 review, non-blocking)
 - Add `VERSIONS_B64` empty-check guard in `release.yml` bash script — silent failure if `versions.html` missing from default branch (non-blocking)
+- Add multi-button dark mode sync test (flagged in PR #304 review, non-blocking)
 - Deprecate `.main` / `.main--fixed` in `_main.scss` — already noted in source; remove in a future version once consumers have migrated to `.container`
 
 ### Deferred (out of scope)
@@ -230,6 +234,9 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 - "Version history" link in style guide side nav uses an absolute gh-pages URL so it works from gh-pages, Netlify, and local dev
 - `_sections--divided` (border-top separator) replaces `_sections--alternating` inside constrained sidebar layouts — the full-bleed `::before` trick on `--alternating` breaks in constrained columns
 - `stripSnippets()` uses three sequential regex replacements: (1) `<details class="sg-snippet">` elements, (2) the `/* ---- Code snippets ---- */` CSS block, (3) the `// Copy buttons` JS event handler block — all three must be present or the Netlify output contains dead code
+- `initDarkMode()` reads `html.dataset.mode` (not the button's `data-mode`) as the source of truth for current state — button attribute is derived/display-only, not authoritative
+- Nav "Versions" link uses the absolute `https://albertcss.craigmcn.com/versions.html` URL (same as sidebar nav) so it resolves correctly from both Netlify (`/albertcss/`) and gh-pages (`/`) contexts; "Style Guide" uses `./` (relative) for the same reason
+- System-preference sync on load (OS dark mode → initial button state) is a known gap; `prefers-color-scheme` already styles via CSS but `html.dataset.mode` and button state are not initialized to match — deferred, non-blocking
 
 ## Key dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,9 +54,11 @@ src/
 │       ├── _tabs.scss
 │       ├── _tooltips.scss
 │       ├── layouts/
+│       │   ├── _container.scss    # Bootstrap-compatible responsive containers; replaces .main/.main--fixed
 │       │   ├── _header.scss
-│       │   ├── _main.scss
-│       │   ├── _sections.scss
+│       │   ├── _main.scss         # Deprecated — kept for backward compat; use .container instead
+│       │   ├── _sections.scss     # Includes .sections--divided (border-top separator)
+│       │   ├── _sidebar-layout.scss  # Two-column CSS Grid: sidebar + main; stacks at sm
 │       │   └── _toolbar.scss
 │       └── utilities/
 │           ├── _aspect-ratio.scss
@@ -161,8 +163,10 @@ git push origin vX.Y.Z
 The workflow builds and deploys to the `gh-pages` branch at `/vX.Y.Z/`, served at:  
 `https://albertcss.craigmcn.com/vX.Y.Z/css/albert.min.css`
 
-The latest published release is always available at:  
-`https://www.craigmcn.com/albertcss/`
+The latest published release is available at both:
+
+- **`https://albertcss.craigmcn.com/css/albert.min.css`** (canonical — gh-pages root, set by release workflow)
+- `https://www.craigmcn.com/albertcss/css/albert.min.css` (legacy Netlify URL — still works)
 
 **Backfill an older tag:**
 
@@ -187,7 +191,7 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 | `/create-pr [title]`   | Create a PR against `main`, then automatically run a code review |
 | `/review-pr [pr]`      | Review the current branch's PR or a specified PR number          |
 
-## Project status (2026-05-14)
+## Project status (2026-05-28)
 
 ### Completed
 
@@ -195,10 +199,16 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 - **Post-review fixes** (PR #279, merged 2026-04-16): brand SVG sizing, FA icon overflow, viewport-aware flip for tooltips + popovers
 - **Dep bumps**: ESLint 9 → 10, Prettier 3.8.3, Vitest 4.1.5 (PRs #280–#283); @babel/preset-env, globals, jsdom, eslint, ip-address, @babel/plugin-transform-modules-systemjs (PRs #284–#290)
 - **Repo hygiene**: `.github/CODEOWNERS` (`* @craigmcn`), branch protection ruleset (1 approval, Admin bypass, `test` status check, block force push + deletion) — both already in place, confirmed 2026-05-01
+- **Yarn 3.3.1 → 4 + Husky** (PR #291, merged 2026-05-20): Yarn 4.14.1 via Corepack, Husky pre-commit hook, full Prettier reformat
+- **SRI + versions index** (PR #295, merged 2026-05-20): SRI hashes computed at release time, `versions.json` upserted on `gh-pages`, `versions.html` page with copy buttons
+- **gh-pages canonical site + HTML snippets** (PR #303, open 2026-05-28): style guide restructured with sidebar nav and `<details class="sg-snippet">` copy drawers per component; `versions.html` at repo root with URL-update warning; `versions.html` linked from side nav; `stripSnippets()` Transform in gulpfile strips drawers for Netlify build; release workflow deploys `dist/` to gh-pages root so `albertcss.craigmcn.com/css/albert.min.css` works after next release; new layout partials (`_container.scss`, `_sidebar-layout.scss`, `_sections--divided`)
 
-### Outstanding
+### In progress / next steps
 
-- Yarn 3.3.1 → 4 upgrade + Husky pre-commit hook (`yarn prettier --check . && yarn lint`)
+- Merge PR #303 and trigger a release — first release after merge completes the gh-pages restructuring (style guide at root, latest CSS/JS at `albertcss.craigmcn.com/`)
+- Add Vitest unit test for `stripSnippets()` to catch regex regressions (flagged in PR #303 review, non-blocking)
+- Add `VERSIONS_B64` empty-check guard in `release.yml` bash script — silent failure if `versions.html` missing from default branch (non-blocking)
+- Deprecate `.main` / `.main--fixed` in `_main.scss` — already noted in source; remove in a future version once consumers have migrated to `.container`
 
 ### Deferred (out of scope)
 
@@ -207,15 +217,19 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 ### Future improvements (TODO)
 
 - **SRI hashes for releases**: ✅ done — computed at release time, stored in `versions.json` on `gh-pages`
-- **GitHub Pages version index**: ✅ done — `index.html` at `albertcss.craigmcn.com/` lists all versions with SRI copy buttons
-- **Example page with HTML snippets**: a living demo page that shows each component with the actual markup, so consumers can copy code directly
-- **Netlify CSS not minified**: `www.craigmcn.com/albertcss/css/albert.min.css` is unminified for v0.14.0 and v0.15.0 (v0.13.0 and earlier are minified). Investigate the Gulp CSS pipeline — likely a regression in the `gulp-sass` or `gulp-if` minification path introduced in the modernise-and-expand work.
+- **GitHub Pages canonical site**: ✅ done (PR #303) — `albertcss.craigmcn.com/` serves full style guide with HTML snippets; `versions.html` linked from nav; Netlify serves snippet-less style guide
+- **Example page with HTML snippets**: ✅ done (PR #303) — `<details class="sg-snippet">` drawers inline in `src/index.html`; stripped for Netlify via `stripSnippets()` in `gulpfile.js`
+- **Netlify CSS not minified**: `www.craigmcn.com/albertcss/css/albert.min.css` was unminified for v0.14.0 and v0.15.0 (v0.13.0 and earlier are minified). Still unresolved — investigate the Gulp CSS pipeline; likely a regression in the `gulp-sass` or `gulp-if` minification path.
 
 ### Key decisions
 
 - Viewport-aware flip for tooltips and popovers implemented in JS (`tooltip.js`, `popover.js`) using `data-tooltip-flip` / `data-popover-flip` attributes; CSS handles the visual swap
 - Spacing utilities use CSS logical properties (e.g. `padding-inline-start`) with Bootstrap-compatible class names; legacy classes kept for backward compatibility
 - `text-bg-*` classes set both background and foreground colour via `--semanticContrast` CSS var for dark-mode safety
+- `albertcss.craigmcn.com` is the canonical home; `www.craigmcn.com/albertcss/` is backward-compat only (snippet-less style guide + latest CSS/JS)
+- "Version history" link in style guide side nav uses an absolute gh-pages URL so it works from gh-pages, Netlify, and local dev
+- `_sections--divided` (border-top separator) replaces `_sections--alternating` inside constrained sidebar layouts — the full-bleed `::before` trick on `--alternating` breaks in constrained columns
+- `stripSnippets()` uses three sequential regex replacements: (1) `<details class="sg-snippet">` elements, (2) the `/* ---- Code snippets ---- */` CSS block, (3) the `// Copy buttons` JS event handler block — all three must be present or the Netlify output contains dead code
 
 ## Key dependencies
 

--- a/src/index.html
+++ b/src/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="x-ua-compatible" content="ie=edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Style Guide</title>
+    <title>Albert CSS</title>
 
     <script>
       (() =>
@@ -268,15 +268,19 @@
         </a>
       </div>
 
-      <h1>Style Guide</h1>
+      <h1>Albert CSS</h1>
 
       <nav id="navigation" class="nav collapsed">
         <ul class="nav__list">
           <li class="nav__item">
-            <a class="nav__link" href="#">Navigation 1</a>
+            <a class="nav__link" href="./">Style Guide</a>
           </li>
           <li class="nav__item">
-            <a class="nav__link" href="#">Navigation 2</a>
+            <a
+              class="nav__link"
+              href="https://albertcss.craigmcn.com/versions.html"
+              >Versions</a
+            >
           </li>
         </ul>
       </nav>

--- a/src/js/__tests__/darkMode.test.js
+++ b/src/js/__tests__/darkMode.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { initDarkMode } from '../darkMode';
+
+describe('initDarkMode', () => {
+  let button;
+
+  beforeEach(() => {
+    document.documentElement.removeAttribute('data-mode');
+    document.body.innerHTML = `
+      <button data-toggle-dark-mode data-mode="dark" type="button">
+        <span data-color="light">dark</span>
+        <span class="d-none" data-color="dark">light</span>
+      </button>
+    `;
+    button = document.querySelector('[data-toggle-dark-mode]');
+    initDarkMode();
+  });
+
+  afterEach(() => {
+    document.documentElement.removeAttribute('data-mode');
+    document.body.innerHTML = '';
+  });
+
+  it('sets dark mode on click', () => {
+    button.click();
+    expect(document.documentElement.dataset.mode).toBe('dark');
+  });
+
+  it('toggles back to light mode on second click', () => {
+    button.click();
+    button.click();
+    expect(document.documentElement.dataset.mode).toBe('light');
+  });
+
+  it('updates button data-mode to light when dark mode is on', () => {
+    button.click();
+    expect(button.dataset.mode).toBe('light');
+  });
+
+  it('restores button data-mode to dark when dark mode is off', () => {
+    button.click();
+    button.click();
+    expect(button.dataset.mode).toBe('dark');
+  });
+
+  it('hides light span and shows dark span when dark mode is on', () => {
+    const lightSpan = button.querySelector('[data-color="light"]');
+    const darkSpan = button.querySelector('[data-color="dark"]');
+    button.click();
+    expect(lightSpan.classList.contains('d-none')).toBe(true);
+    expect(darkSpan.classList.contains('d-none')).toBe(false);
+  });
+
+  it('restores span visibility when dark mode is toggled off', () => {
+    const lightSpan = button.querySelector('[data-color="light"]');
+    const darkSpan = button.querySelector('[data-color="dark"]');
+    button.click();
+    button.click();
+    expect(lightSpan.classList.contains('d-none')).toBe(false);
+    expect(darkSpan.classList.contains('d-none')).toBe(true);
+  });
+
+  it('does nothing if no toggle buttons found', () => {
+    document.body.innerHTML = '';
+    expect(() => initDarkMode()).not.toThrow();
+  });
+});

--- a/src/js/darkMode.js
+++ b/src/js/darkMode.js
@@ -1,0 +1,24 @@
+export function initDarkMode() {
+  const html = document.documentElement;
+  const buttons = document.querySelectorAll('[data-toggle-dark-mode]');
+  if (!buttons.length) return;
+
+  function applyMode(dark) {
+    html.dataset.mode = dark ? 'dark' : 'light';
+    buttons.forEach((btn) => {
+      btn.dataset.mode = dark ? 'light' : 'dark';
+      btn.querySelectorAll('[data-color="light"]').forEach((el) => {
+        el.classList.toggle('d-none', dark);
+      });
+      btn.querySelectorAll('[data-color="dark"]').forEach((el) => {
+        el.classList.toggle('d-none', !dark);
+      });
+    });
+  }
+
+  buttons.forEach((btn) => {
+    btn.addEventListener('click', () => {
+      applyMode(html.dataset.mode !== 'dark');
+    });
+  });
+}

--- a/src/js/scripts.js
+++ b/src/js/scripts.js
@@ -1,5 +1,6 @@
 import Bouncer from 'formbouncerjs';
 import { initAccordion } from './accordion';
+import { initDarkMode } from './darkMode';
 import { initDropdown } from './dropdown';
 import { initPopover } from './popover';
 import { initTabs } from './tabs';
@@ -18,6 +19,7 @@ window.addEventListener('load', function () {
   });
 
   initAccordion();
+  initDarkMode();
   // Both return an AbortController for cleanup if the component is ever re-initialized.
   // Not needed here — the page has a single load lifetime.
   initDropdown();


### PR DESCRIPTION
## What

- Add `darkMode.js` module with `initDarkMode()` — listens for `[data-toggle-dark-mode]` clicks, toggles `html[data-mode]` between `dark`/`light`, updates `btn.dataset.mode`, and swaps `data-color` span visibility. Wired into `scripts.js`.
- Rename page `<title>` and header `<h1>` from "Style Guide" to "Albert CSS".
- Replace placeholder nav links ("Navigation 1/2") with "Style Guide" (`./`) and "Versions" (`https://albertcss.craigmcn.com/versions.html`).
- 7 new unit tests in `darkMode.test.js` covering toggle, attribute updates, and span visibility.

## Why

The dark mode toggle button (`data-toggle-dark-mode`) existed in the HTML with no JS handler — clicks did nothing. The nav links were never updated from placeholder text after the style guide restructure in PR #303.

## Test plan

- [ ] Dark mode toggle button in header toolbar activates/deactivates dark mode
- [ ] Dark mode demo button in the Colours section shows "Toggle light mode" when dark is active
- [ ] Page title reads "Albert CSS" in browser tab
- [ ] Header shows "Albert CSS" instead of "Style Guide"
- [ ] Nav shows "Style Guide" and "Versions" links
- [ ] All 112 Vitest tests pass (`npx vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)