### PR TITLE
Replace Raleway with Outfit as heading font

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,7 +196,7 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 
 ### Completed
 
-- **Modernise and expand** (PR #278, merged 2026-04-16): badges, modal, accordion, tabs, dropdown, tooltips, popovers, spacing/display/text/overflow/position/shadow/border/z-index/aspect-ratio/background/grid utilities, button group
+- **Modernize and expand** (PR #278, merged 2026-04-16): badges, modal, accordion, tabs, dropdown, tooltips, popovers, spacing/display/text/overflow/position/shadow/border/z-index/aspect-ratio/background/grid utilities, button group
 - **Post-review fixes** (PR #279, merged 2026-04-16): brand SVG sizing, FA icon overflow, viewport-aware flip for tooltips + popovers
 - **Dep bumps**: ESLint 9 → 10, Prettier 3.8.3, Vitest 4.1.5 (PRs #280–#283); @babel/preset-env, globals, jsdom, eslint, ip-address, @babel/plugin-transform-modules-systemjs (PRs #284–#290)
 - **Repo hygiene**: `.github/CODEOWNERS` (`* @craigmcn`), branch protection ruleset (1 approval, Admin bypass, `test` status check, block force push + deletion) — both already in place, confirmed 2026-05-01
@@ -207,6 +207,7 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 
 ### In progress / next steps
 
+- **Font replacement** (branch `feat/font-comparison`, 2026-06-06) — Raleway → Outfit; ready to commit and PR
 - **Merge PR #304** (fix/dark-mode-nav) — dark mode toggle, nav, title fixes; [#304](https://github.com/craigmcn/albertcss/pull/304)
 - **Trigger a release** after PR #304 merges — first release since PR #303 will update `albertcss.craigmcn.com/` root with new `index.html` (snippets, dark mode, correct nav)
 - Add Vitest unit test for `stripSnippets()` to catch regex regressions (flagged in PR #303 review, non-blocking)
@@ -217,6 +218,10 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 ### Deferred (out of scope)
 
 - Toasts/Snackbars, Progress bars, Spinners, Breadcrumbs, Pagination, Stepper/Wizard, Avatars, Chips/Tags
+
+### Font
+
+- ✅ Replaced Raleway with Outfit (2026-06-06, branch `feat/font-comparison`) — single-story "a", geometric sans-serif, Google Fonts; h1–h4 at weight 500, h5–h6 at weight 600; stack: `Outfit, Futura, Avenir, 'Century Gothic', Candara, sans-serif`
 
 ### Future improvements (TODO)
 
@@ -237,6 +242,8 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 - `initDarkMode()` reads `html.dataset.mode` (not the button's `data-mode`) as the source of truth for current state — button attribute is derived/display-only, not authoritative
 - Nav "Versions" link uses the absolute `https://albertcss.craigmcn.com/versions.html` URL (same as sidebar nav) so it resolves correctly from both Netlify (`/albertcss/`) and gh-pages (`/`) contexts; "Style Guide" uses `./` (relative) for the same reason
 - System-preference sync on load (OS dark mode → initial button state) is a known gap; `prefers-color-scheme` already styles via CSS but `html.dataset.mode` and button state are not initialized to match — deferred, non-blocking
+- Heading font is Outfit (not Raleway); `$heading-stack` in `_fonts.scss` replaces `$raleway-stack`; h1–h4 at weight 500, h5–h6 at weight 600 (heavier to compensate for smaller size); `.subheading` inside h5/h6 drops back to weight 500
+- Outfit fallback stack chosen for geometric character: Futura (macOS), Avenir (macOS alternate), Century Gothic (Windows), Candara (Windows humanist fallback) — do not trust web-search research on whether a font has a single-story "a"; verify visually in the browser (Montserrat and Plus Jakarta Sans were both incorrectly reported as single-story by research tools)
 
 ## Key dependencies
 

--- a/src/css/scss/_base.scss
+++ b/src/css/scss/_base.scss
@@ -24,7 +24,18 @@ h3,
 h4,
 h5,
 h6 {
-  font-family: $raleway-stack;
+  font-family: $heading-stack;
+}
+
+h1,
+h2,
+h3,
+h4 {
+  font-weight: 500;
+}
+
+h5,
+h6 {
   font-weight: 600;
 }
 
@@ -48,6 +59,11 @@ h6 {
   h3 &,
   h4 & {
     font-size: 0.9em;
+  }
+
+  h5 &,
+  h6 & {
+    font-weight: 500;
   }
 }
 

--- a/src/css/scss/_fonts.scss
+++ b/src/css/scss/_fonts.scss
@@ -2,9 +2,8 @@
  * Fonts
  */
 
-@import url('https://fonts.googleapis.com/css2?family=Raleway:wght@200;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@500;600&display=swap');
 
-$raleway-stack:
-  Raleway, 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
+$heading-stack: Outfit, Futura, Avenir, 'Century Gothic', Candara, sans-serif;
 
 $system-stack: system-ui, sans-serif !default;

--- a/src/css/scss/_fonts.scss
+++ b/src/css/scss/_fonts.scss
@@ -2,7 +2,7 @@
  * Fonts
  */
 
-@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@200;500;600&display=swap');
 
 $heading-stack: Outfit, Futura, Avenir, 'Century Gothic', Candara, sans-serif;
 

--- a/src/css/scss/layouts/_header.scss
+++ b/src/css/scss/layouts/_header.scss
@@ -55,7 +55,7 @@
   }
 
   h1 {
-    font-family: $raleway-stack;
+    font-family: $heading-stack;
     font-size: 1.25rem;
     grid-area: site;
     margin-bottom: 0.5rem;
@@ -91,8 +91,8 @@
 }
 
 .brand {
-  font-weight: 600; // aligned with standard h*
-  font-family: $raleway-stack;
+  font-weight: 500; // aligned with standard h*
+  font-family: $heading-stack;
   font-size: 1.25rem;
   grid-area: brand;
   margin: 0.5rem 0 0.5rem 1rem;

--- a/src/css/scss/utilities/_text.scss
+++ b/src/css/scss/utilities/_text.scss
@@ -6,7 +6,7 @@
  */
 
 .lede {
-  font-family: $raleway-stack;
+  font-family: $heading-stack;
   font-size: 1.1em;
   font-weight: 200;
 }


### PR DESCRIPTION
## Summary

- Replaces Raleway with Outfit (geometric sans-serif, single-story "a") as the heading font
- Renames `$raleway-stack` → `$heading-stack` in `_fonts.scss`; updates all consumers (`_base.scss`, `_header.scss`, `_text.scss`)
- Heading weight hierarchy: h1–h4 at 500, h5–h6 at 600 (heavier weight compensates for smaller size); `.subheading` inside h5/h6 drops back to 500
- Fallback stack: `Outfit, Futura, Avenir, 'Century Gothic', Candara, sans-serif`
- Google Fonts loads weights 500 and 600 only

## Test plan

- [ ] `yarn build` completes without errors
- [ ] Typography section of style guide renders Outfit headings at the correct weights (visually lighter than Raleway was)
- [ ] h5/h6 headings are visually distinguishable from body text
- [ ] `.brand` in the header uses the new font and weight
- [ ] Dark mode toggle still works (unrelated to font, sanity check)
- [ ] ⚠️ `.lede` uses `font-weight: 200` but only weights 500/600 are loaded — browser will substitute 500; verify the `.lede` appearance is acceptable or load weight 300 if a lighter variant is desired

🤖 Generated with [Claude Code](https://claude.com/claude-code)