### PR TITLE
chore: set dev server port to 3010

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -165,7 +165,7 @@ gulp.task('reload', (done) => {
 // Browser sync
 gulp.task('browserSync', () => {
   browserSync.init({
-    port: 3020,
+    port: 3010,
     server: './tmp',
     ui: false,
   });


### PR DESCRIPTION
## Summary

- Changes BrowserSync port from 3020 to 3010 in `gulpfile.js`
- Resolves a conflict with the `files` repo, which also uses port 3020
- All active projects now have unique dev server ports

## Test plan

- [ ] Run `yarn dev` and confirm the local server starts at `http://localhost:3010`