### PR TITLE
chore: force postcss to 8.5.15 via Yarn resolution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 | `/create-pr [title]`   | Create a PR against `main`, then automatically run a code review |
 | `/review-pr [pr]`      | Review the current branch's PR or a specified PR number          |
 
-## Project status (2026-06-08)
+## Project status (2026-06-17)
 
 ### Completed
 
@@ -205,9 +205,11 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 - **gh-pages canonical site + HTML snippets** (PR #303, merged 2026-05-28): style guide restructured with sidebar nav and `<details class="sg-snippet">` copy drawers per component; `versions.html` at repo root with URL-update warning; `versions.html` linked from side nav; `stripSnippets()` Transform in gulpfile strips drawers for Netlify build; release workflow deploys `dist/` to gh-pages root so `albertcss.craigmcn.com/css/albert.min.css` works after next release; new layout partials (`_container.scss`, `_sidebar-layout.scss`, `_sections--divided`)
 - **Dark mode toggle + nav fixes** (PR #304, merged 2026-05-28): add `darkMode.js` module (`initDarkMode()`), rename title/h1 "Style Guide" → "Albert CSS", replace placeholder nav links with "Style Guide" (`./`) and "Versions" (absolute gh-pages URL); 7 new unit tests
 - **Font replacement** (PR #312, merged 2026-06-06, v0.17.0 released): Raleway → Outfit; single-story "a", geometric sans-serif; h1–h4 weight 500, h5–h6 weight 600; `$heading-stack` in `_fonts.scss`
+- **postcss security fix** (PR #320, open 2026-06-17): Yarn `resolutions` field pins `postcss` to `^8.5.15`, closing Dependabot alert #111 (medium, CVSS 6.1 — XSS via unescaped `</style>` in CSS Stringify Output); removes stale lockfile entries for postcss 7.0.39, 8.5.9, nanoid 3.3.11, picocolors 0.2.1
 
 ### In progress / next steps
 
+- **PR #320** — postcss resolution security fix; awaiting review/merge
 - Add multi-button dark mode sync test (flagged in PR #304 review, non-blocking)
 - Deprecate `.main` / `.main--fixed` in `_main.scss` — already noted in source; remove in a future version once consumers have migrated to `.container`
 
@@ -240,6 +242,7 @@ Global slash commands (in `~/.claude/commands/`) available in any project:
 - System-preference sync on load (OS dark mode → initial button state) is a known gap; `prefers-color-scheme` already styles via CSS but `html.dataset.mode` and button state are not initialized to match — deferred, non-blocking
 - Heading font is Outfit (not Raleway); `$heading-stack` in `_fonts.scss` replaces `$raleway-stack`; h1–h4 at weight 500, h5–h6 at weight 600 (heavier to compensate for smaller size); `.subheading` inside h5/h6 drops back to weight 500
 - Outfit fallback stack chosen for geometric character: Futura (macOS), Avenir (macOS alternate), Century Gothic (Windows), Candara (Windows humanist fallback) — do not trust web-search research on whether a font has a single-story "a"; verify visually in the browser (Montserrat and Plus Jakarta Sans were both incorrectly reported as single-story by research tools)
+- `resolutions: { postcss: "^8.5.15" }` in `package.json` is the correct Yarn 4 mechanism for forcing transitive dep versions; `@gulp-sourcemaps/identity-map` required a forced major upgrade (7 → 8) which is technically unsupported but safe in practice — the passing build confirms no breakage
 
 ## Key dependencies
 

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/craigmcn/albertcss/issues"
   },
   "homepage": "https://github.com/craigmcn/albertcss#readme",
+  "resolutions": {
+    "postcss": "^8.5.15"
+  },
   "devDependencies": {
     "@babel/core": "^7.29.7",
     "@babel/preset-env": "^7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6890,15 +6890,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11":
-  version: 3.3.11
-  resolution: "nanoid@npm:3.3.11"
-  bin:
-    nanoid: bin/nanoid.cjs
-  checksum: 10/73b5afe5975a307aaa3c95dfe3334c52cdf9ae71518176895229b8d65ab0d1c0417dd081426134eb7571c055720428ea5d57c645138161e7d10df80815527c48
-  languageName: node
-  linkType: hard
-
 "nanoid@npm:^3.3.12":
   version: 3.3.12
   resolution: "nanoid@npm:3.3.12"
@@ -7410,13 +7401,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picocolors@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "picocolors@npm:0.2.1"
-  checksum: 10/3b0f441f0062def0c0f39e87b898ae7461c3a16ffc9f974f320b44c799418cabff17780ee647fda42b856a1dc45897e2c62047e1b546d94d6d5c6962f45427b2
-  languageName: node
-  linkType: hard
-
 "picocolors@npm:^1.0.0, picocolors@npm:^1.1.1":
   version: 1.1.1
   resolution: "picocolors@npm:1.1.1"
@@ -7474,16 +7458,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^7.0.16":
-  version: 7.0.39
-  resolution: "postcss@npm:7.0.39"
-  dependencies:
-    picocolors: "npm:^0.2.1"
-    source-map: "npm:^0.6.1"
-  checksum: 10/9635b3a444673d1e50ea67c68382201346b54d7bb69729fff5752a794d57ca5cae7f6fafd4157a9ab7f9ddac30a0d5e548c1196653468cbae3c2758dbc2f5662
-  languageName: node
-  linkType: hard
-
 "postcss@npm:^8.5.15":
   version: 8.5.15
   resolution: "postcss@npm:8.5.15"
@@ -7492,17 +7466,6 @@ __metadata:
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
   checksum: 10/d02ad19eb1e0fa53a1229ee6d53807eb88f903f2b9a8cac66993367f3ac7dd3b97238c783a54ccbf4145f82f6ca9a5cbd58f089846285d759c8a3259fbea8318
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.6":
-  version: 8.5.9
-  resolution: "postcss@npm:8.5.9"
-  dependencies:
-    nanoid: "npm:^3.3.11"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10/b34661c6efca87f7bf747c6c943435e4bfef7617a238c3719103e607c605d16720682fb121b7ebd4f7f748228dfdf8711b82f7ffed80a5c4a9249c070ed5fd87
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Adds a `resolutions` field to `package.json` pinning `postcss` to `^8.5.15`
- Fixes Dependabot alert #111 (medium, CVSS 6.1): PostCSS XSS via unescaped `</style>` in CSS Stringify Output
- Two vulnerable instances were resolved: `gulp-autoprefixer` (had 8.5.9) and `@gulp-sourcemaps/identity-map` (had 7.0.39, a forced major upgrade); both now use 8.5.15

## Test plan

- [ ] `yarn install` completes without errors
- [ ] `yarn why postcss` confirms all instances resolve to 8.5.15
- [ ] `yarn build` succeeds (CSS + JS pipeline intact)
- [ ] `yarn test` passes (118 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)