### PR TITLE
fix: restore CSS minification (gulp-sass 6 outputStyle→style)

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,6 +3,7 @@ import gulpif from 'gulp-if';
 import parseArgs from 'minimist';
 import { Transform } from 'stream';
 import { applyStripSnippets } from './src/js/stripSnippets.js';
+import { sassOptions } from './src/js/sassOptions.js';
 import * as sassInit from 'sass';
 import gulpSass from 'gulp-sass';
 import autoprefixer from 'gulp-autoprefixer';
@@ -29,15 +30,6 @@ const browserSync = browserSyncCreate.create();
 const sass = gulpSass(sassInit);
 
 const inputScss = './src/**/*.scss';
-
-const sassOptions = {
-  default: {
-    style: 'expanded',
-  },
-  minified: {
-    style: 'compressed',
-  },
-};
 
 gulp.task('sass', function () {
   return gulp

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -32,11 +32,10 @@ const inputScss = './src/**/*.scss';
 
 const sassOptions = {
   default: {
-    errLogToConsole: true,
-    outputStyle: 'expanded',
+    style: 'expanded',
   },
   minified: {
-    outputStyle: 'compressed',
+    style: 'compressed',
   },
 };
 

--- a/src/js/__tests__/sassOptions.test.js
+++ b/src/js/__tests__/sassOptions.test.js
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import * as sass from 'sass';
+import { sassOptions } from '../sassOptions.js';
+
+const scss = `
+.foo {
+  color: red;
+
+  .bar {
+    color: blue;
+  }
+}
+`;
+
+describe('sassOptions', () => {
+  it('compiles the default style as expanded (readable) CSS', () => {
+    const { css } = sass.compileString(scss, sassOptions.default);
+
+    expect(css).toContain('\n');
+  });
+
+  it('compiles the minified style as compressed (single-line) CSS', () => {
+    const { css } = sass.compileString(scss, sassOptions.minified);
+
+    expect(css).not.toContain('\n');
+    expect(css.length).toBeLessThan(
+      sass.compileString(scss, sassOptions.default).css.length,
+    );
+  });
+});

--- a/src/js/sassOptions.js
+++ b/src/js/sassOptions.js
@@ -1,0 +1,12 @@
+// Dart Sass's modern compileString/compileStringAsync API (used by gulp-sass
+// 6+) takes a `style` option, not the legacy renderSync API's `outputStyle`.
+// Unknown option keys are silently ignored, so passing the wrong name here
+// produces valid but unminified "minified" output instead of an error.
+export const sassOptions = {
+  default: {
+    style: 'expanded',
+  },
+  minified: {
+    style: 'compressed',
+  },
+};


### PR DESCRIPTION
## Summary
- `gulp-sass` 6.0.0 (PR #150, merged 2024-12-02) switched from the legacy Sass JS API to the modern `compileString` API, which uses `style` instead of `outputStyle`. The old `outputStyle: 'compressed'` option in `gulpfile.js` was silently ignored, so `albert.min.css` has been built expanded (unminified) since v0.14.0.
- Switches `sassOptions` to use `style` instead of `outputStyle` (and drops the now-unused legacy `errLogToConsole` option), restoring real minification: `dist/css/albert.min.css` drops from 78,652 → 59,694 bytes locally.
- Fixes #338 for all future releases. See the issue for backfill options for already-published versions (v0.14.0–v0.18.0), which are out of scope for this PR.

## Test plan
- [x] `yarn build` — confirmed `dist/css/albert.min.css` is now compressed (no whitespace/comments) and ~24% smaller than `albert.css`
- [x] `yarn test` — 123 tests passing
- [x] `yarn lint` — clean