### PR TITLE
test: cover dark mode sync across multiple toggle buttons

### DIFF
--- a/src/js/__tests__/darkMode.test.js
+++ b/src/js/__tests__/darkMode.test.js
@@ -110,4 +110,24 @@ describe('initDarkMode', () => {
     expect(lightEl.classList.contains('d-none')).toBe(false);
     expect(darkEl.classList.contains('d-none')).toBe(true);
   });
+
+  it('syncs data-mode across multiple toggle buttons when one is clicked', () => {
+    document.body.innerHTML = `
+      <button data-toggle-dark-mode data-mode="dark" type="button" id="header-toggle"></button>
+      <button data-toggle-dark-mode data-mode="dark" type="button" id="footer-toggle"></button>
+    `;
+    initDarkMode();
+    const headerToggle = document.getElementById('header-toggle');
+    const footerToggle = document.getElementById('footer-toggle');
+
+    headerToggle.click();
+    expect(document.documentElement.dataset.mode).toBe('dark');
+    expect(headerToggle.dataset.mode).toBe('light');
+    expect(footerToggle.dataset.mode).toBe('light');
+
+    footerToggle.click();
+    expect(document.documentElement.dataset.mode).toBe('light');
+    expect(headerToggle.dataset.mode).toBe('dark');
+    expect(footerToggle.dataset.mode).toBe('dark');
+  });
 });


### PR DESCRIPTION
## Summary
- Adds a test rendering two independent `[data-toggle-dark-mode]` buttons and confirms clicking either one syncs `html[data-mode]` and the `data-mode` attribute on both buttons
- Closes coverage gap flagged in PR #304's review

Closes #336

## Test plan
- [x] `vitest run src/js/__tests__/darkMode.test.js` — 13 passed
- [x] Full suite: 126 passed
- [x] `eslint src/js` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)