### PR TITLE
ci: bump GitHub Actions to current majors

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           ref: ${{ steps.version.outputs.tag }}
 
@@ -43,7 +43,7 @@ jobs:
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: yarn

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,13 +12,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Enable Corepack
         run: corepack enable
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version-file: '.node-version'
           cache: yarn


### PR DESCRIPTION
## Summary
- Bumps `actions/checkout` v4 → v7 and `actions/setup-node` v4 → v7 in both `test.yml` and `release.yml`
- No workflow logic changes needed for either major bump

Closes #335

## Test plan
- [x] `prettier --check` on both workflow files
- [ ] CI run on this PR validates both actions still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)