### PR TITLE
fix(deps): pin brace-expansion to 5.0.7 (Dependabot #129)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   ],
   "resolutions": {
     "postcss": "^8.5.15",
-    "ws": "^8.21.0"
+    "ws": "^8.21.0",
+    "brace-expansion@npm:^5.0.5": "^5.0.7"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2846,12 +2846,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+"brace-expansion@npm:^5.0.7":
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #129 (high, CVSS): `brace-expansion` DoS via exponential-time expansion of consecutive non-expanding `{}` groups
- Two copies of `brace-expansion` exist in the tree: the 1.x line (via `minimatch@3.1.5`) was already patched at 1.1.16; the 5.x line (via `minimatch@10.2.5`) was still at the vulnerable 5.0.5
- Added a scoped `resolutions` entry (`"brace-expansion@npm:^5.0.5": "^5.0.7"`) so only the vulnerable 5.x range is pinned, leaving the already-safe 1.x range untouched — same pattern used for the existing `postcss` and `ws` pins

## Test plan
- [x] `yarn install` resolves `brace-expansion` to 5.0.7 for the `^5.0.5` range
- [x] `yarn test` — 126 tests pass
- [x] `yarn lint` — clean
- [x] `yarn prettier --check .` — clean (ran via pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)