### PR TITLE
chore(deps): force immutable to patched versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
   "resolutions": {
     "postcss": "^8.5.15",
     "ws": "^8.21.0",
-    "brace-expansion@npm:^5.0.5": "^5.0.7"
+    "brace-expansion@npm:^5.0.5": "^5.0.7",
+    "immutable@npm:^3": "^4.3.9",
+    "immutable@npm:^5.1.5": "^5.1.8"
   },
   "devDependencies": {
     "@babel/core": "^7.29.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5596,17 +5596,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:^3":
-  version: 3.8.3
-  resolution: "immutable@npm:3.8.3"
-  checksum: 10/29db366d4dff83b0b296150c351b08db24837005909a71c123d860c1d2a40605f19a3ecd56d1e96be9799e947ddf7906897a28fa2e81f0b8c63c652b6bfe5550
+"immutable@npm:^4.3.9":
+  version: 4.3.9
+  resolution: "immutable@npm:4.3.9"
+  checksum: 10/bb951f0b69528e820f18a7968a49147c66962e71ba5abbad87ffa780c1cc0b7da7f471903770bbe7697701cc8d94b20541ac5c7ab2b4d89c5735f5798eff6310
   languageName: node
   linkType: hard
 
-"immutable@npm:^5.1.5":
-  version: 5.1.5
-  resolution: "immutable@npm:5.1.5"
-  checksum: 10/7aec2740239772ec8e92e793c991bd809203a97694f4ff3a18e50e28f9a6b02393ad033d87b458037bdf8c0ea37d4446d640e825f6171df3405cf6cf300ce028
+"immutable@npm:^5.1.8":
+  version: 5.1.9
+  resolution: "immutable@npm:5.1.9"
+  checksum: 10/dc61ea6f79897320a048f193dec703dff25ad7bb633c3a0294677d2f258764c88da06e7c2b53d1aa51b6657c98d9f1c7341f49735b9b802fe6e834122cf78dcd
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fixes Dependabot alerts #136-139 (all high severity) for transitive `immutable` pulled in by `browser-sync`/`browser-sync-ui` (3.8.3) and `sass` (5.1.5)
- Neither upstream package has bumped its own `immutable` dependency, so pin via Yarn `resolutions` to `^4.3.9` (for the `^3` range) and `^5.1.8` (for the `^5.1.5` range) — resolves to 4.3.9 and 5.1.9 respectively
- Covers a 32-bit trie overflow DoS and a hash-collision algorithmic complexity DoS in `Immutable.Map`/`Set`/`List`

## Test plan
- [x] `yarn install` resolves cleanly to immutable 4.3.9 / 5.1.9
- [x] `yarn test` — 126 tests passing
- [x] `yarn lint` — clean
- [x] `yarn build` — succeeds
- [x] `yarn serve` — Browsersync starts and serves normally (UI is disabled in gulpfile, so `browser-sync-ui`'s immutable usage isn't even exercised at runtime)