### PR TITLE
fix(deps): widen brace-expansion resolution to ^5.0.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "resolutions": {
     "postcss": "^8.5.25",
     "ws": "^8.21.0",
-    "brace-expansion@npm:^5.0.5": "^5.0.7",
+    "brace-expansion@npm:^5.0.7": "^5.0.9",
     "immutable@npm:^3": "^4.3.9",
     "immutable@npm:^5.1.5": "^5.1.8"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2843,16 +2843,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"brace-expansion@npm:^5.0.7":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
-  dependencies:
-    balanced-match: "npm:^4.0.2"
-  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
-  languageName: node
-  linkType: hard
-
-"brace-expansion@npm:^5.0.8":
+"brace-expansion@npm:^5.0.5, brace-expansion@npm:^5.0.8":
   version: 5.0.9
   resolution: "brace-expansion@npm:5.0.9"
   dependencies:


### PR DESCRIPTION
## Summary
- Resolves Dependabot alert #141 (high severity): `brace-expansion` DoS via unbounded expansion length, affecting versions <= 5.0.7, fixed in 5.0.8.
- The existing `resolutions` entry pinned `brace-expansion` to `^5.0.7` (from a prior alert), but 5.0.7 is itself the vulnerable version. Widened the forced resolution to `^5.0.9`, matching the version already resolved elsewhere in the tree via other dependents.

## Test plan
- [x] `yarn install` — confirms only `brace-expansion@5.0.9` (5.x line) and `1.1.16` (legacy minimatch@3 line) remain in the tree
- [x] `yarn why brace-expansion` — no copies inside the vulnerable `<= 5.0.7` range
- [x] `yarn test --run` — 126 tests pass
- [x] `yarn lint` — clean
- [x] `yarn build` — succeeds